### PR TITLE
Add a placeholder event for SR2017 Kickstart

### DIFF
--- a/_events/2016-10-15-kickstart.md
+++ b/_events/2016-10-15-kickstart.md
@@ -1,0 +1,6 @@
+---
+title: SR2017 Kickstart
+date: 2017-10-15T09:00:00Z
+type: kickstart
+location: To Be Announced
+---


### PR DESCRIPTION
Although we don't know the location yet, we do know the date.  This adds
a general "SR2017 Kickstart" event to the list of events.