### PR TITLE
Remove timezones from events

### DIFF
--- a/_events/2016-10-15-bristol-kickstart.md
+++ b/_events/2016-10-15-bristol-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Bristol Kickstart
-date: 2016-10-15T10:00:00Z
+date: 2016-10-15 10:00:00
 type: kickstart
 location: Bristol University
 ---

--- a/_events/2016-10-15-oxford-kickstart.md
+++ b/_events/2016-10-15-oxford-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Oxford Kickstart
-date: 2016-10-15T10:00:00Z
+date: 2016-10-15 10:00:00
 type: kickstart
 location: The Kings Centre
 ---

--- a/_events/2016-10-15-soton-kickstart.md
+++ b/_events/2016-10-15-soton-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton Kickstart
-date: 2016-10-15T10:00:00Z
+date: 2016-10-15 10:00:00
 type: kickstart
 location: Southampton University
 ---


### PR DESCRIPTION
Recording these dates with a timezone isn't entirely useful since
a reader then needs to work out whether BST applies on that date.
Remove the timezone information so we can just write dates in a
more natural form (also drop the redundant 'T' in the middle which
makes reading them harder).