### PR TITLE
Enable future mode when running the dev version of the site

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,5 +8,5 @@ task :deploy do
 end
 
 task :dev do
-  sh('bundle exec jekyll serve --drafts')
+  sh('bundle exec jekyll serve --drafts --config _config.yml,_dev.yml')
 end

--- a/_dev.yml
+++ b/_dev.yml
@@ -1,0 +1,1 @@
+future: true


### PR DESCRIPTION
Currently you can't see posts set to publish in the future when running a dev version of the site, this is a proposed fix for it, where you can see all future posts only for the dev site.