### PR TITLE
Avoid duplicate proxying userman

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -79,10 +79,6 @@ http {
       proxy_set_header Host srobo.github.io;
     }
 
-    location /password/ {
-      proxy_pass https://saffron.studentrobotics.org/userman/;
-    }
-
     location /userman/ {
       proxy_pass https://saffron.studentrobotics.org/userman/;
     }
@@ -114,6 +110,7 @@ http {
     rewrite ^/sponsors             /contact redirect;
     rewrite ^/about/sponsors       /contact redirect;
     rewrite ^/key_dates            /events redirect;
+    rewrite ^/password             /userman/ permanent;
 
     location / {
       try_files       $uri.html $uri $uri/ =404;


### PR DESCRIPTION
Redirect /password to /userman instead, as saffron does.