### PR TITLE
Handle urls with slashes in a manner Gerrit copes with

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -67,7 +67,7 @@ http {
     }
 
     location /gerrit/ {
-      proxy_pass https://saffron.studentrobotics.org/gerrit/;
+      proxy_pass https://saffron.studentrobotics.org$request_uri;
     }
 
     location /docs/python/ {


### PR DESCRIPTION
This applies the same fix here as was applied in puppet at 370157e
(https://srobo.org/cgit/server/puppet.git/commit/?id=370157e84f6).

This should fix https://www.studentrobotics.org/trac/ticket/3023 _yet again_.
