### PR TITLE
Only regenerate the certificate if missing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,9 +13,13 @@ end
 
 directory '_secrets'
 
-task :cert => [:_secrets] do
-  sh('openssl req -subj \'/CN=studentrobotics.org/O=John Doe/C=GB\' -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout _secrets/key.pem -out _secrets/cert.pem')
+%W[_secrets/cert.pem _secrets/key.pem].each do |cert_file|
+  file cert_file => [:_secrets] do
+    sh('openssl req -subj \'/CN=studentrobotics.org/O=John Doe/C=GB\' -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout _secrets/key.pem -out _secrets/cert.pem')
+  end
 end
+
+task :cert => ['_secrets/cert.pem', '_secrets/key.pem']
 
 task :run => [:cert, :build] do
   sh('docker run --rm -p 80:80 -p 443:443 -v $(pwd)/_secrets:/etc/secrets --name srobo srobo/website')

--- a/Rakefile
+++ b/Rakefile
@@ -11,8 +11,9 @@ task :dev do
   sh('bundle exec jekyll serve --drafts --config _config.yml')
 end
 
-task :cert do
-  sh('mkdir -p _secrets')
+directory '_secrets'
+
+task :cert => [:_secrets] do
   sh('openssl req -subj \'/CN=studentrobotics.org/O=John Doe/C=GB\' -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout _secrets/key.pem -out _secrets/cert.pem')
 end
 


### PR DESCRIPTION
This avoids the need to re-accept a new invalid certificate every time the container is run.