### PR TITLE
Add reverse proxy for media consent forms

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -108,6 +108,10 @@ http {
       proxy_pass https://saffron.studentrobotics.org/comp-api/;
     }
 
+    location /mediaconsent/ {
+      proxy_pass https://saffron.studentrobotics.org/mediaconsent/;
+    }
+
     location /style/ {
       proxy_pass       https://srobo.github.io/style/;
       proxy_set_header Host srobo.github.io;


### PR DESCRIPTION
I think that this should add a reverse proxy so that it's possible to access the MCF generation/hosting thing at https://www.studentrobotics.org/mediaconsent/