### PR TITLE
Add /comp redirect to SR2017 comp event page

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -126,6 +126,9 @@ http {
     rewrite ^/feed.php             /feed.xml redirect;
     rewrite ^/password             /userman/ permanent;
 
+    # Ephemeral redirects (will probably change over time and/or not be useful after a point in time)
+    rewrite ^/comp                 /events/sr2017/competition/ redirect;
+
     location / {
       try_files       $uri.html $uri $uri/ =404;
       index           index.html index.htm;


### PR DESCRIPTION
This URL gets printed on the tickets. It's less typing (assuming anyone
actually bothers to type it in at all).