### PR TITLE
Proxying for the competition website 

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -108,6 +108,18 @@ http {
       proxy_pass https://saffron.studentrobotics.org/comp-api/;
     }
 
+    # Provide access to the competition pages under the normal prefix
+    location /comp/ {
+      proxy_pass       https://srobo.github.io/competition-website/comp/;
+      proxy_set_header Host srobo.github.io;
+    }
+    # Also provide access under the prefix which github insists on using
+    # so that the secondary resources (JS, CSS, etc.) load.
+    location /competition-website/ {
+      proxy_pass       https://srobo.github.io/competition-website/;
+      proxy_set_header Host srobo.github.io;
+    }
+
     location /mediaconsent/ {
       proxy_pass https://saffron.studentrobotics.org/mediaconsent/;
     }

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -108,13 +108,19 @@ http {
       proxy_pass https://saffron.studentrobotics.org/comp-api/;
     }
 
+    # During the competition we un-comment this block to override the homepage
+    # with the comeptition-specific one
+    # location = / {
+    #   proxy_pass       https://srobo.github.io/competition-website/;
+    #   proxy_set_header Host srobo.github.io;
+    # }
     # Provide access to the competition pages under the normal prefix
     location /comp/ {
       proxy_pass       https://srobo.github.io/competition-website/comp/;
       proxy_set_header Host srobo.github.io;
     }
     # Also provide access under the prefix which github insists on using
-    # so that the secondary resources (JS, CSS, etc.) load.
+    # so that the secondary resources (JS, CSS, etc.) load
     location /competition-website/ {
       proxy_pass       https://srobo.github.io/competition-website/;
       proxy_set_header Host srobo.github.io;


### PR DESCRIPTION
This includes the /comp pages which can go live immediately (while they're not quite ready, they're not yet linked from anywhere and there's no reason to keep them hidden before the competition).

This also includes the override for the competition homepage, which is deliberately commented out so that the current homepage will remain for this week.

Once this PR is merged I'll open another one that un-comments the competition homepage override which can be merged on the morning of the competition.