### PR TITLE
Ensure that /comp/ links are cleaned

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -118,6 +118,14 @@ http {
     location /comp/ {
       proxy_pass       https://srobo.github.io/competition-website/comp/;
       proxy_set_header Host srobo.github.io;
+
+      sub_filter "/competition-website/comp/" "/comp/";
+      sub_filter_once off;
+      sub_filter_last_modified on;
+      # Tell GitHub that we want these pages to be sent to us uncompressed
+      # otherwise the sub_filter above doesn't work. We'll compress it on the
+      # way out anyway, so clients don't lose anything by us doing this.
+      proxy_set_header Accept-Encoding "";
     }
     # Also provide access under the prefix which github insists on using
     # so that the secondary resources (JS, CSS, etc.) load


### PR DESCRIPTION
This has us rewrite the links to the individual pages so that they all end up at `/comp/$page` rather than `/competition-website/comp/$page` as previously.

Fixes srobo/competition-website#3.