### PR TITLE
Make the competition homepage live

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -110,18 +110,18 @@ http {
 
     # During the competition we un-comment this block to override the homepage
     # with the comeptition-specific one
-    # location = / {
-    #   proxy_pass       https://srobo.github.io/competition-website/comp/;
-    #   proxy_set_header Host srobo.github.io;
-    #
-    #   sub_filter "/competition-website/comp/" "/comp/";
-    #   sub_filter_once off;
-    #   sub_filter_last_modified on;
-    #   # Tell GitHub that we want these pages to be sent to us uncompressed
-    #   # otherwise the sub_filter above doesn't work. We'll compress it on the
-    #   # way out anyway, so clients don't lose anything by us doing this.
-    #   proxy_set_header Accept-Encoding "";
-    # }
+    location = / {
+      proxy_pass       https://srobo.github.io/competition-website/comp/;
+      proxy_set_header Host srobo.github.io;
+
+      sub_filter "/competition-website/comp/" "/comp/";
+      sub_filter_once off;
+      sub_filter_last_modified on;
+      # Tell GitHub that we want these pages to be sent to us uncompressed
+      # otherwise the sub_filter above doesn't work. We'll compress it on the
+      # way out anyway, so clients don't lose anything by us doing this.
+      proxy_set_header Accept-Encoding "";
+    }
     # Provide access to the competition pages under the normal prefix
     location /comp/ {
       proxy_pass       https://srobo.github.io/competition-website/comp/;

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -111,7 +111,7 @@ http {
     # During the competition we un-comment this block to override the homepage
     # with the comeptition-specific one
     # location = / {
-    #   proxy_pass       https://srobo.github.io/competition-website/;
+    #   proxy_pass       https://srobo.github.io/competition-website/comp/;
     #   proxy_set_header Host srobo.github.io;
     # }
     # Provide access to the competition pages under the normal prefix

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -113,6 +113,14 @@ http {
     # location = / {
     #   proxy_pass       https://srobo.github.io/competition-website/comp/;
     #   proxy_set_header Host srobo.github.io;
+    #
+    #   sub_filter "/competition-website/comp/" "/comp/";
+    #   sub_filter_once off;
+    #   sub_filter_last_modified on;
+    #   # Tell GitHub that we want these pages to be sent to us uncompressed
+    #   # otherwise the sub_filter above doesn't work. We'll compress it on the
+    #   # way out anyway, so clients don't lose anything by us doing this.
+    #   proxy_set_header Accept-Encoding "";
     # }
     # Provide access to the competition pages under the normal prefix
     location /comp/ {


### PR DESCRIPTION
**Do not merge until Friday evening at the earliest**

PR for making the competition homepage live.

This also includes some fixes to make the relevant (otherwise commented out) block actually work. Ideally when we revert this we will only revert the commit which removes the comments.

NB: if there's a better way to make this easier to enable/disable I'd be happy to hear it. I don't like commented code.