### PR TITLE
Update the banner button to direct to the compete page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,7 +12,7 @@ layout: default
     <div class="fixed-width">
       <div class="hero-text">
         <h1>An annual robotics competition for young people aged 16-18</h1>
-        <a class="button button-hero" href="{{ '/about' | prepend: site.baseurl }}">Learn more</a>
+        <a class="button button-hero" href="{{ '/compete' | prepend: site.baseurl }}">How to compete</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The current home button leads to /about which is not as useful to possible competitors as /compete.

Change the button to redirect to /compete