### PR TITLE
Windows dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'kramdown'
 gem 'jekyll'
 gem 'jekyll-feed'
 gem 'jekyll-paginate'
+gem 'tzinfo',           :platforms => :mswin
+gem 'tzinfo-data',      :platforms => :mswin

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'kramdown'
 gem 'jekyll'
 gem 'jekyll-feed'
 gem 'jekyll-paginate'
-gem 'tzinfo',           :platforms => :mswin
-gem 'tzinfo-data',      :platforms => :mswin
+gem 'tzinfo',           :platforms => [:mswin, :mingw, :x64_mingw]
+gem 'tzinfo-data',      :platforms => [:mswin, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x86-mingw32)
     ffi (1.9.23)
+    ffi (1.9.23-x86-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
@@ -60,9 +62,15 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thor (0.20.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2018.5)
+      tzinfo (>= 1.0.0)
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   jekyll

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ DEPENDENCIES
   kramdown
   neat
   rake
+  tzinfo
+  tzinfo-data
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
This adds `tzinfo` and `tzinfo-data` dependency on Windows.

This turns out to be a dependency of Jekyll which isn't specified on their part. This seems to be a [known issue](https://github.com/jekyll/jekyll/issues/5935), so you'd hope they'd fix it, but that's apparently too complicated.