### PR TITLE
Avoid polling on windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem 'jekyll-feed'
 gem 'jekyll-paginate'
 gem 'tzinfo',           :platforms => [:mswin, :mingw, :x64_mingw]
 gem 'tzinfo-data',      :platforms => [:mswin, :mingw, :x64_mingw]
+
+# Avoid polling on windows
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2018.5)
       tzinfo (>= 1.0.0)
+    wdm (0.1.1)
 
 PLATFORMS
   ruby
@@ -81,6 +82,7 @@ DEPENDENCIES
   rake
   tzinfo
   tzinfo-data
+  wdm (>= 0.1.0)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
This change is suggested by Jekyll when run on Windows.