### PR TITLE
Avoid syntax warnings from Liquid

### DIFF
--- a/events.html
+++ b/events.html
@@ -18,8 +18,8 @@ permalink: /events/
             <div class="column d-12-12 l-3-12">Date and time</div>
             <div class="column d-12-12 l-4-12">Location</div>
           </li>
-          {% assign sorted = (site.events | sort: 'date') | reverse %}
-          {% for event in sorted %}
+          {% assign sorted = site.events | sort: 'date' %}
+          {% for event in sorted reversed %}
           {% if event.date > site.time %}
           <li class="row">
           {% else %}

--- a/events.ics
+++ b/events.ics
@@ -4,7 +4,8 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:https://studentrobotics.org/
 METHOD:PUBLISH
-{% for event in (site.events | sort: 'date') %}BEGIN:VEVENT
+{% assign sorted = site.events | sort: 'date' %}
+{% for event in sorted %}BEGIN:VEVENT
 UID:{{ event.url | prepend: site.baseurl | prepend: site.url }}
 DTSTART:{{ event.date | date: "%Y%m%dT%H%M%S" }}
 DTSTAMP:{{ event.date | date: "%Y%m%dT%H%M%S" }}


### PR DESCRIPTION
This appears to behave the same as the previous spelling, but avoids the warnings.

Specifically this removes these warnings I get when I run `rake dev`:
```
    Liquid Warning: Liquid syntax error (line 16): Expected dotdot but found pipe in "{{(site.events | sort: 'date') | reverse }}" in events.html
    Liquid Warning: Liquid syntax error (line 5): Expected dotdot but found pipe in "event in (site.events | sort: 'date')" in events.ics
```