### PR TITLE
Add detail to Southampton Kickstart event

### DIFF
--- a/_events/sr2019/southampton-kickstart.md
+++ b/_events/sr2019/southampton-kickstart.md
@@ -21,10 +21,6 @@ The Southampton kickstart is being held at the University of Southampton at:
 EEE Building (32),
 University of Southampton,
 University Road,
-Southampton,
-EEE Building (32),  
-University of Southampton,  
-University Road,  
 Southampton,  
 SO17 1BJ  
 

--- a/_events/sr2019/southampton-kickstart.md
+++ b/_events/sr2019/southampton-kickstart.md
@@ -22,7 +22,11 @@ EEE Building (32),
 University of Southampton,
 University Road,
 Southampton,
-SO17 1BJ
+EEE Building (32),  
+University of Southampton,  
+University Road,  
+Southampton,  
+SO17 1BJ  
 
 For Public transport or driving instructions, see the University of Southampton's information on [getting to our campuses][soton-campus-directions] (scroll down to Highfield campus).
 

--- a/_events/sr2019/southampton-kickstart.md
+++ b/_events/sr2019/southampton-kickstart.md
@@ -18,9 +18,9 @@ We'll have desktops available for students to use, however feel free to bring pe
 
 The Southampton kickstart is being held at the University of Southampton at:
 
-EEE Building (32),
-University of Southampton,
-University Road,
+EEE Building (32),  
+University of Southampton,  
+University Road,  
 Southampton,  
 SO17 1BJ  
 

--- a/_events/sr2019/southampton-kickstart.md
+++ b/_events/sr2019/southampton-kickstart.md
@@ -12,13 +12,25 @@ be announced and robotics kits will be handed out to the teams.
 If you are unable to attend Kickstart, please [let us know][teams-contact] so we
 can arrange another way to get you your kit.
 
+We'll have desktops available for students to use, however feel free to bring personal laptops if you prefer.
+
 ## Directions
 
-* How to [get to campus][soton-campus-directions]
+The Southampton kickstart is being held at the University of Southampton at:
 
-* [On-campus directions][soton-directions]
+EEE Building (32),
+University of Southampton,
+University Road,
+Southampton,
+SO17 1BJ
 
-* [Where to find food][soton-food-map]
+For Public transport or driving instructions, see the University of Southampton's information on [getting to our campuses][soton-campus-directions] (scroll down to Highfield campus).
+
+Once you're on campus you can follow the [on-campus directions][soton-directions].
+
+## Food
+
+There are plenty of places to get food on and nearby campus see [where to find food][soton-food-map].
 
 ## Schedule
 
@@ -32,4 +44,4 @@ can arrange another way to get you your kit.
 [teams-contact]: mailto:teams@studentrobotics.org
 [soton-food-map]: https://drive.google.com/open?id=1vDqr-yQh-OO7MzVa_OiuKD5xUrEsLprr
 [soton-directions]: {{ site.baseurl }}/resources/sr2019/southampton-kickstart-directions.pdf
-[soton-campus-directions]: http://www.southampton.ac.uk/about/visit/getting-to-our-campuses.page#highfield
+[soton-campus-directions]: http://www.southampton.ac.uk/about/visit/getting-to-our-campuses.page

--- a/_events/sr2019/southampton-kickstart.md
+++ b/_events/sr2019/southampton-kickstart.md
@@ -24,7 +24,7 @@ University Road,
 Southampton,  
 SO17 1BJ  
 
-For Public transport or driving instructions, see the University of Southampton's information on [getting to our campuses][soton-campus-directions] (scroll down to Highfield campus).
+For public transport or driving instructions, see the University of Southampton's information on [getting to our campuses][soton-campus-directions] (scroll down to Highfield campus).
 
 Once you're on campus you can follow the [on-campus directions][soton-directions].
 


### PR DESCRIPTION
Add some extra details to the Southampton kickstart event:
- Add an Address
- Flesh out getting to campus page, as the anchor link doesn't work.
- Mention we'll have computers available.