### PR TITLE
Remove seemingly now redundant argument

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: Push Docker image
           command: |
-            docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
             rake deploy
 
 


### PR DESCRIPTION
The version of Docker now available doesn't seem to support '-e'.