### PR TITLE
Update nginx config

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -42,7 +42,7 @@ http {
     ssl                     on;
     ssl_certificate         /etc/secrets/cert.pem;
     ssl_certificate_key     /etc/secrets/key.pem;
-    ssl_protocols           TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols           TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
     ssl_ciphers             HIGH:!aNULL:!MD5:!RC4:!EXPORT;
 
     proxy_pass_request_headers on;

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -34,12 +34,11 @@ http {
   }
 
   server {
-    listen            443 default_server;
-    listen            [::]:443 default_server ipv6only=on;
+    listen            443 default_server ssl;
+    listen            [::]:443 default_server ssl ipv6only=on;
     server_name       localhost;
     root              /var/www;
 
-    ssl                     on;
     ssl_certificate         /etc/secrets/cert.pem;
     ssl_certificate_key     /etc/secrets/key.pem;
     ssl_protocols           TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -34,8 +34,8 @@ http {
   }
 
   server {
-    listen            443 default_server ssl;
-    listen            [::]:443 default_server ssl ipv6only=on;
+    listen            443 default_server ssl http2;
+    listen            [::]:443 default_server ssl http2 ipv6only=on;
     server_name       localhost;
     root              /var/www;
 


### PR DESCRIPTION
Various updates to our NGINX config to cope with the fact that it's now 2018.

Specifically this:
- enables TLS 1.3 and HTTP/2 (the latter of which is mentioned in #25)
- fixes a warning due to the way we were specifying TLS

I plan to follow this with a PR which updates our cypher suites, but this should be useful enough as it is.