### PR TITLE
Add short-hand access to the rules

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -81,10 +81,6 @@ http {
     location /docs/python/ {
       proxy_pass https://patience.studentrobotics.org/docs/python/;
     }
-
-    location /rules/ {
-      proxy_pass https://patience.studentrobotics.org/docs/rules/;
-    }
     
     location /docs/ {
       proxy_pass       https://srobo.github.io/docs/;
@@ -170,6 +166,7 @@ http {
     rewrite ^/key_dates            /events redirect;
     rewrite ^/feed.php             /feed.xml redirect;
     rewrite ^/password             /userman/ permanent;
+    rewrite ^/rules                /docs/rules/ permanent;
 
     location / {
       try_files       $uri.html $uri $uri/ =404;

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -82,6 +82,10 @@ http {
       proxy_pass https://patience.studentrobotics.org/docs/python/;
     }
 
+    location /rules/ {
+      proxy_pass https://patience.studentrobotics.org/docs/rules/;
+    }
+    
     location /docs/ {
       proxy_pass       https://srobo.github.io/docs/;
       proxy_set_header Host srobo.github.io;

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -81,7 +81,7 @@ http {
     location /docs/python/ {
       proxy_pass https://patience.studentrobotics.org/docs/python/;
     }
-    
+
     location /docs/ {
       proxy_pass       https://srobo.github.io/docs/;
       proxy_set_header Host srobo.github.io;


### PR DESCRIPTION
Add a short-hand URL for accessing the rules, rather than srobo.org/docs/rules, or srobo.org/docs, then clicking rules.

If my understanding of the setup is correct, this should also allow srobo.org/rules to redirect to it.