### PR TITLE
Cancel the London December Tech Day event

### DIFF
--- a/_events/sr2019/london-tech-day-december.md
+++ b/_events/sr2019/london-tech-day-december.md
@@ -4,6 +4,7 @@ date: 2018-12-15 10:00:00
 layout: event
 type: techday
 location: Thread, Whitechapel
+cancelled: true
 ---
 
 Tech Days are opportunities for teams to get help if they're struggling with a

--- a/_events/sr2019/london-tech-day-december.md
+++ b/_events/sr2019/london-tech-day-december.md
@@ -17,8 +17,6 @@ limited to six teams, so be sure to [let us know][teams-contact] if you'd like
 to attend. For this Tech Day, please express your interest by Wednesday 12th
 December.
 
-~~Please bring your laptops!~~
-
 **Due to lack of interest this Tech Day will not be running.**
 
 [teams-contact]: mailto:teams@studentrobotics.org

--- a/_events/sr2019/london-tech-day-december.md
+++ b/_events/sr2019/london-tech-day-december.md
@@ -16,32 +16,8 @@ limited to six teams, so be sure to [let us know][teams-contact] if you'd like
 to attend. For this Tech Day, please express your interest by Wednesday 12th
 December.
 
-**Please bring your laptops!**
+~~Please bring your laptops!~~
 
-## Directions
+**Due to lack of interest this Tech Day will not be running.**
 
-The London Kickstart is being held in the [offices of Thread][venue-map] at:
-
-1 Alie Street,
-Whitechapel,
-London,
-E1 8DE
-
-The easiest way to travel will be by public transport -- Aldgate, Aldgate East
-and Tower Gateway stations are all within a five minute walk, and Liverpool
-Street station is a ten minute walk away. There are also a large number of
-busses which stop nearby.
-
-Upon arrival at reception, please ask for Thread.
-
-## Schedule
-
-| Time  | Info |
-|-------|------|
-| 10:00 | Doors Open. |
-| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
-| 13:00 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them. |
-| 17:00 | Finish. |
-
-[venue-map]: https://goo.gl/13LbAL
 [teams-contact]: mailto:teams@studentrobotics.org

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -11,7 +11,11 @@ layout: page
     <div class="column l-4-12">
       <div class="card thin-card">
         <ul class="detail-list">
-          <li><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i> {{ page.date | date: "%e %B %Y at %l%P" }}</li>
+          {% if page.cancelled %}
+            <li><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i> <s>{{ page.date | date: "%e %B %Y at %l%P" }}</s></li>
+          {% else %}
+            <li><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i> {{ page.date | date: "%e %B %Y at %l%P" }}</li>
+          {% endif %}
           <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ page.location }}</li>
         </ul>
       </div>

--- a/events.html
+++ b/events.html
@@ -20,7 +20,7 @@ permalink: /events/
           </li>
           {% assign sorted = site.events | sort: 'date' %}
           {% for event in sorted reversed %}
-          {% if event.date > site.time %}
+          {% if event.date > site.time and event.cancelled != true %}
           <li class="row">
           {% else %}
           <li class="row past-event">
@@ -29,7 +29,11 @@ permalink: /events/
               <a href="{{ event.url | prepend: site.baseurl }}">{{ event.title }}</a>
             </div>
             <div class="column d-12-12 l-2-12"><span class="tag tag-{{ event.type }}">{{ event.type }}</span></div>
-            <div class="column d-12-12 l-3-12">{{ event.date | date: "%e %B %Y at %l%P" }}</div>
+            {% if event.cancelled %}
+              <div class="column d-12-12 l-3-12"><s>{{ event.date | date: "%e %B %Y at %l%P" }}</s></div>
+            {% else %}
+              <div class="column d-12-12 l-3-12">{{ event.date | date: "%e %B %Y at %l%P" }}</div>
+            {% endif %}
             <div class="column d-12-12 l-4-12">{{ event.location }}</div>
           </li>
           {% endfor %}

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ layout: home
           {% if any_events %}
           <ul class="event-list">
             {% for event in site.events %}
-            {% if event.date > site.time %}
+            {% if event.date > site.time and event.cancelled != true %}
             <li class="event">
               <p class="event-name"><a href="{{ event.url | prepend: site.baseurl }}">{{ event.title }}</a></p>
               <p class="event-details">


### PR DESCRIPTION
Remove the directions and schedule from the page as they no longer apply, but leave the introduction in place and add a bold statement that the event is not running.

This replaces #118.

*This event page*:
![image](https://user-images.githubusercontent.com/336212/50034087-23f20700-fff3-11e8-9cbd-475a0cd6c65d.png)

*All events page*:
![image](https://user-images.githubusercontent.com/336212/50034080-163c8180-fff3-11e8-8151-23f588c37dad.png)
