### PR TITLE
Ensure redirect consistency even when GitHub pages isn't

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -85,6 +85,13 @@ http {
     location /docs/ {
       proxy_pass       https://srobo.github.io/docs/;
       proxy_set_header Host srobo.github.io;
+      # Work around github.io issuing HTTP (not HTTPS) redirects when
+      # redirecting to cannonical forms of urls. For example, given the url
+      # "https://studentrobotics.org/docs/programming", which we proxy to
+      # "https://srobo.github.io/docs/programming", it issues a redirect to
+      # "http://srobo.github.io/docs/programming/" which we would otherwise
+      # expose to the client, sending them away from our domain.
+      proxy_redirect   http://srobo.github.io/docs/ /docs/;
     }
 
     location /userman/ {
@@ -112,6 +119,8 @@ http {
     # location = / {
     #   proxy_pass       https://srobo.github.io/competition-website/comp/;
     #   proxy_set_header Host srobo.github.io;
+    #   # Work around github.io redirect issue (see above)
+    #   proxy_redirect   http://srobo.github.io/competition-website/comp/ /;
     #
     #   sub_filter "/competition-website/comp/" "/comp/";
     #   sub_filter_once off;
@@ -125,6 +134,8 @@ http {
     location /comp/ {
       proxy_pass       https://srobo.github.io/competition-website/comp/;
       proxy_set_header Host srobo.github.io;
+      # Work around github.io redirect issue (see above)
+      proxy_redirect   http://srobo.github.io/competition-website/comp/ /comp/;
 
       sub_filter "/competition-website/comp/" "/comp/";
       sub_filter_once off;
@@ -139,6 +150,8 @@ http {
     location /competition-website/ {
       proxy_pass       https://srobo.github.io/competition-website/;
       proxy_set_header Host srobo.github.io;
+      # Work around github.io redirect issue (see above)
+      proxy_redirect   http://srobo.github.io/competition-website/ /competition-website/;
     }
 
     location /mediaconsent/ {
@@ -156,6 +169,8 @@ http {
     location /style/ {
       proxy_pass       https://srobo.github.io/style/;
       proxy_set_header Host srobo.github.io;
+      # Work around github.io redirect issue (see above)
+      proxy_redirect   http://srobo.github.io/style/ /style/;
     }
 
     rewrite ^/schools/how_to_enter /compete redirect;


### PR DESCRIPTION
GitHub pages issues redirects to canonical urls in the form of insecure urls (which then upgrade when requested). I'm assuming that this is a bug and have reported it to GitHub. Specifically, they canonicalise from `/docs/programming` to `/docs/programming/` (which is a good thing overall) by issuing a redirect to `http://srobo.github.io/docs/programming/` (note the `http://` protocol). This is insecure :( and is different to the url which our proxy is expecting, meaning that the proxy misses it.

The fix here is to detect the insecure urls in the redirects and proxy those too.

Further mitigates https://github.com/srobo/website/issues/122