### PR TITLE
Require bundler 1.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,10 @@ jobs:
       - checkout
       - setup_remote_docker
 
-      - run: ./scripts/install-gems
+      - run:
+          name: Install gems
+          # Changing this? Also change the README and the other use here (below)
+          command: gem install bundler -v '~> 1' rake
       - run: docker info
       - run: rake build
 
@@ -20,7 +23,10 @@ jobs:
       - checkout
       - setup_remote_docker
 
-      - run: ./scripts/install-gems
+      - run:
+          name: Install gems
+          # Changing this? Also change the README and the other use here (above)
+          command: gem install bundler -v '~> 1' rake
       - run: docker info
       - run: rake build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Install gems
           # Changing this? Also change the README and the other use here (below)
-          command: gem install bundler -v '~> 1' rake
+          command: gem install 'bundler:~>1' rake
       - run: docker info
       - run: rake build
 
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Install gems
           # Changing this? Also change the README and the other use here (above)
-          command: gem install bundler -v '~> 1' rake
+          command: gem install 'bundler:~>1' rake
       - run: docker info
       - run: rake build
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The Student Robotics public website.
 
 1. [Install Ruby][install-ruby]
 
-2. Install Bundler and Rake
+2. Install Bundler (1.x) and Rake
 
     ```
-    $ ./scripts/install-gems
+    $ gem install bundler -v '~> 1' rake
     ```
 
 3. Install [Node Package Manager (npm)][install-npm]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Student Robotics public website.
 2. Install Bundler (1.x) and Rake
 
     ```
-    $ gem install bundler -v '~> 1' rake
+    $ gem install 'bundler:~>1' rake
     ```
 
 3. Install [Node Package Manager (npm)][install-npm]

--- a/scripts/install-gems
+++ b/scripts/install-gems
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec gem install bundler rake


### PR DESCRIPTION
Version 2.x has a whole new file format which we don't want to switch over to yet as it would break a bunch of developer's setups.

This also moves the command back into the README so that it's easier for Windows developers to do the right thing.