### PR TITLE
Drop condition on depedency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'tzinfo',           :platforms => [:mswin, :mingw, :x64_mingw]
 gem 'tzinfo-data',      :platforms => [:mswin, :mingw, :x64_mingw]
 
 # Avoid polling on windows
-gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'wdm', '>= 0.1.0'


### PR DESCRIPTION
This means that the gem will be installed on all platforms, avoiding the `Gemfile.lock` changing between platforms.