### PR TITLE
Cancel the London March tech day

### DIFF
--- a/_events/sr2019/london-tech-day-march.md
+++ b/_events/sr2019/london-tech-day-march.md
@@ -4,6 +4,7 @@ date: 2019-03-09 10:00:00
 layout: event
 type: techday
 location: Thread, Whitechapel
+cancelled: true
 ---
 
 Tech Days are opportunities for teams to get help if they're struggling with a
@@ -15,32 +16,6 @@ London Tech Days will only run of there is sufficient interest. Spaces are
 limited to six teams, so be sure to [let us know][teams-contact] if you'd like
 to attend.
 
-**Please bring your laptops!**
+**Due to lack of interest this Tech Day will not be running.**
 
-## Directions
-
-The London Kickstart is being held in the [offices of Thread][venue-map] at:
-
-1 Alie Street,
-Whitechapel,
-London,
-E1 8DE
-
-The easiest way to travel will be by public transport -- Aldgate, Aldgate East
-and Tower Gateway stations are all within a five minute walk, and Liverpool
-Street station is a ten minute walk away. There are also a large number of
-busses which stop nearby.
-
-Upon arrival at reception, please ask for Thread.
-
-## Schedule
-
-| Time  | Info |
-|-------|------|
-| 10:00 | Doors Open. |
-| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
-| 13:00 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them. |
-| 17:00 | Finish. |
-
-[venue-map]: https://goo.gl/13LbAL
 [teams-contact]: mailto:teams@studentrobotics.org


### PR DESCRIPTION
Due to lack of interest, we won't be running one.