### PR TITLE
Disable custom media consent generation endpoint

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -154,9 +154,10 @@ http {
       proxy_redirect   http://srobo.github.io/competition-website/ /competition-website/;
     }
 
-    location /mediaconsent/ {
-      proxy_pass https://patience.studentrobotics.org/mediaconsent/;
-    }
+    # Disable custom media consent endpoint
+    #location /mediaconsent/ {
+    #  proxy_pass https://patience.studentrobotics.org/mediaconsent/;
+    #}
 
     location /tickets/ {
       proxy_pass https://patience.studentrobotics.org/tickets/;


### PR DESCRIPTION
This won't be setup this year, so remove it incase there are links lying around.