### PR TITLE
Enable competition mode

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -116,20 +116,20 @@ http {
 
     # During the competition we un-comment this block to override the homepage
     # with the comeptition-specific one
-    # location = / {
-    #   proxy_pass       https://srobo.github.io/competition-website/comp/;
-    #   proxy_set_header Host srobo.github.io;
-    #   # Work around github.io redirect issue (see above)
-    #   proxy_redirect   http://srobo.github.io/competition-website/comp/ /;
-    #
-    #   sub_filter "/competition-website/comp/" "/comp/";
-    #   sub_filter_once off;
-    #   sub_filter_last_modified on;
-    #   # Tell GitHub that we want these pages to be sent to us uncompressed
-    #   # otherwise the sub_filter above doesn't work. We'll compress it on the
-    #   # way out anyway, so clients don't lose anything by us doing this.
-    #   proxy_set_header Accept-Encoding "";
-    # }
+    location = / {
+      proxy_pass       https://srobo.github.io/competition-website/comp/;
+      proxy_set_header Host srobo.github.io;
+      # Work around github.io redirect issue (see above)
+      proxy_redirect   http://srobo.github.io/competition-website/comp/ /;
+
+      sub_filter "/competition-website/comp/" "/comp/";
+      sub_filter_once off;
+      sub_filter_last_modified on;
+      # Tell GitHub that we want these pages to be sent to us uncompressed
+      # otherwise the sub_filter above doesn't work. We'll compress it on the
+      # way out anyway, so clients don't lose anything by us doing this.
+      proxy_set_header Accept-Encoding "";
+    }
     # Provide access to the competition pages under the normal prefix
     location /comp/ {
       proxy_pass       https://srobo.github.io/competition-website/comp/;


### PR DESCRIPTION
This un-comments out the overriding of the homepage to being the "live" homepage which usually resides at /comp/.

This fixes https://github.com/srobo/tasks/issues/262.

Please review, however this won't be merged or deployed until Saturday morning.