### PR TITLE
Add soundtrack for SR2019

### DIFF
--- a/_events/sr2019/competition.md
+++ b/_events/sr2019/competition.md
@@ -74,6 +74,11 @@ We have a limited amount of free parking on site for competitors.
 
 You can also download a PDF of the [venue map][venue-map].
 
+## Soundtrack
+
+- [Epic Playlist](https://open.spotify.com/user/theorangeone97/playlist/5NgaMpnbl01iWzpwvQEdoo?si=Axd6U2KqR3qLROne2gb2Fw)
+- [_Chill_ Playlist](https://open.spotify.com/user/theorangeone97/playlist/4VZp716neJl4zWmGVY6k4L?si=Qos3XkdQQvK9-MBWzgXmHA)
+
 [teams-contact]: mailto:teams@studentrobotics.org
 [soton-campus-directions]: http://www.southampton.ac.uk/about/visit/getting-to-our-campuses.page
 [mcf-link]: {{ '/resources/sr2019/media-consent.pdf' | prepend: site.baseurl }}


### PR DESCRIPTION
Lots of teams commented on the quality of the soundtrack this year, and several asked where they could find it. Rather than pointing people to _my_ website, we might as well just link to them directly on the competition page.

(These links don't require an account, but _may_ require an account to play, which is fine)