### PR TITLE
Restore year-agnostic signup forms

### DIFF
--- a/_includes/team-signup.html
+++ b/_includes/team-signup.html
@@ -34,4 +34,13 @@
         <a class="button" href="mailto:{{ site.emails.teams }}" target="_blank">Speak to someone</a>
       </div>
     </div>
+    <div id="mergeRow-gdpr" class="mergeRow gdpr-mergeRow content__gdprBlock mc-field-group">
+        <div class="content__gdpr">
+            <p>Student Robotics will use the information you provide on this form to contact you around leading a team at Student Robotics. We will contact you via email.</p>
+            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="gdpr[24613]" tabindex="-1" value="Y"></div>
+        </div>
+        <div class="content__gdprLegal">
+            <p>We use MailChimp as our contacting platform. By clicking below to sign up, you acknowledge that your information will be transferred to MailChimp for processing. Learn more about MailChimp's privacy practices <a href="https://mailchimp.com/legal/" target="_blank">here</a>.</p>
+        </div>
+    </div>
 </form>

--- a/_includes/team-signup.html
+++ b/_includes/team-signup.html
@@ -1,88 +1,37 @@
-<!-- Begin MailChimp Signup Form -->
-<div id="mc_embed_signup">
-<form action="https://studentrobotics.us12.list-manage.com/subscribe/post?u=1af17c2a3426de258620aae46&amp;id=dd9ef8ad9f" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="form form-left show-labels validate" target="_blank" novalidate>
+<form action="//studentrobotics.us12.list-manage.com/subscribe/post?u=1af17c2a3426de258620aae46&amp;id=dd7d04139d"
+      method="post"
+      id="mc-embedded-subscribe-form"
+      name="mc-embedded-subscribe-form"
+      class="form form-left show-labels validate"
+      target="_blank"
+      novalidate>
     <div id="mc_embed_signup_scroll">
-
-<div class="mc-field-group">
-	<label for="mce-EMAIL">Email Address </label>
-	<input type="email" value="" name="EMAIL" class="required email full-width" id="mce-EMAIL">
-</div>
-<div class="mc-field-group">
-	<label for="mce-FNAME">First Name </label>
-	<input type="text" value="" name="FNAME" class="required full-width" id="mce-FNAME">
-</div>
-<div class="mc-field-group">
-	<label for="mce-LNAME">Last Name </label>
-	<input type="text" value="" name="LNAME" class="required full-width" id="mce-LNAME">
-</div>
-<div class="mc-field-group size1of2">
-	<label for="mce-PHONE">Phone Number </label>
-	<input type="text" name="PHONE" class="full-width" value="" id="mce-PHONE">
-</div>
-<div class="mc-field-group">
-	<label for="mce-MMERGE3">School/Institution Name </label>
-	<input type="text" value="" name="MMERGE3" class="required full-width" id="mce-MMERGE3">
-</div>
-<div class="mc-address-group">
-	<div class="mc-field-group">
-	    <label for="mce-MMERGE5-addr1">School/Institution Address </label>
-		<input type="text" value="" maxlength="70" name="MMERGE5[addr1]" id="mce-MMERGE5-addr1" class="required full-width">
-	</div>
-	<div class="mc-field-group">
-	    <label for="mce-MMERGE5-addr2">Address Line 2</label>
-		<input type="text" value="" maxlength="70" name="MMERGE5[addr2]" id="mce-MMERGE5-addr2" class="full-width">
-	</div>
-	<div class="mc-field-group size1of2">
-	    <label for="mce-MMERGE5-city">City</label>
-		<input type="text" value="" maxlength="40" name="MMERGE5[city]" id="mce-MMERGE5-city" class="required full-width">
-	</div>
-	<div class="mc-field-group size1of2">
-	    <label for="mce-MMERGE5-state">State/Province/Region</label>
-	<input type="text" value="" maxlength="20" name="MMERGE5[state]" id="mce-MMERGE5-state" class="required full-width">
-	</div>
-	<div class="mc-field-group size1of2">
-	    <label for="mce-MMERGE5-zip">Postal / Zip Code</label>
-		<input type="text" value="" maxlength="10" name="MMERGE5[zip]" id="mce-MMERGE5-zip" class="required full-width">
-	</div>
-	<div class="mc-field-group size1of2">
-	    <label for="mce-MMERGE5-country">Country</label>
-		<select name="MMERGE5[country]" id="mce-MMERGE5-country" class="required full-width"><option value="164">USA</option><option value="286">Aaland Islands</option><option value="274">Afghanistan</option><option value="2">Albania</option><option value="3">Algeria</option><option value="178">American Samoa</option><option value="4">Andorra</option><option value="5">Angola</option><option value="176">Anguilla</option><option value="175">Antigua And Barbuda</option><option value="6">Argentina</option><option value="7">Armenia</option><option value="179">Aruba</option><option value="8">Australia</option><option value="9">Austria</option><option value="10">Azerbaijan</option><option value="11">Bahamas</option><option value="12">Bahrain</option><option value="13">Bangladesh</option><option value="14">Barbados</option><option value="15">Belarus</option><option value="16">Belgium</option><option value="17">Belize</option><option value="18">Benin</option><option value="19">Bermuda</option><option value="20">Bhutan</option><option value="21">Bolivia</option><option value="325">Bonaire, Saint Eustatius and Saba</option><option value="22">Bosnia and Herzegovina</option><option value="23">Botswana</option><option value="181">Bouvet Island</option><option value="24">Brazil</option><option value="180">Brunei Darussalam</option><option value="25">Bulgaria</option><option value="26">Burkina Faso</option><option value="27">Burundi</option><option value="28">Cambodia</option><option value="29">Cameroon</option><option value="30">Canada</option><option value="31">Cape Verde</option><option value="32">Cayman Islands</option><option value="33">Central African Republic</option><option value="34">Chad</option><option value="35">Chile</option><option value="36">China</option><option value="185">Christmas Island</option><option value="37">Colombia</option><option value="204">Comoros</option><option value="38">Congo</option><option value="183">Cook Islands</option><option value="268">Costa Rica</option><option value="275">Cote D'Ivoire</option><option value="40">Croatia</option><option value="276">Cuba</option><option value="298">Curacao</option><option value="41">Cyprus</option><option value="42">Czech Republic</option><option value="318">Democratic Republic of the Congo</option><option value="43">Denmark</option><option value="44">Djibouti</option><option value="289">Dominica</option><option value="187">Dominican Republic</option><option value="45">Ecuador</option><option value="46">Egypt</option><option value="47">El Salvador</option><option value="48">Equatorial Guinea</option><option value="49">Eritrea</option><option value="50">Estonia</option><option value="51">Ethiopia</option><option value="189">Falkland Islands</option><option value="191">Faroe Islands</option><option value="52">Fiji</option><option value="53">Finland</option><option value="54">France</option><option value="193">French Guiana</option><option value="277">French Polynesia</option><option value="56">Gabon</option><option value="57">Gambia</option><option value="58">Georgia</option><option value="59">Germany</option><option value="60">Ghana</option><option value="194">Gibraltar</option><option value="61">Greece</option><option value="195">Greenland</option><option value="192">Grenada</option><option value="196">Guadeloupe</option><option value="62">Guam</option><option value="198">Guatemala</option><option value="270">Guernsey</option><option value="63">Guinea</option><option value="65">Guyana</option><option value="200">Haiti</option><option value="66">Honduras</option><option value="67">Hong Kong</option><option value="68">Hungary</option><option value="69">Iceland</option><option value="70">India</option><option value="71">Indonesia</option><option value="278">Iran</option><option value="279">Iraq</option><option value="74">Ireland</option><option value="323">Isle of Man</option><option value="75">Israel</option><option value="76">Italy</option><option value="202">Jamaica</option><option value="78">Japan</option><option value="288">Jersey  (Channel Islands)</option><option value="79">Jordan</option><option value="80">Kazakhstan</option><option value="81">Kenya</option><option value="203">Kiribati</option><option value="82">Kuwait</option><option value="83">Kyrgyzstan</option><option value="84">Lao People's Democratic Republic</option><option value="85">Latvia</option><option value="86">Lebanon</option><option value="87">Lesotho</option><option value="88">Liberia</option><option value="281">Libya</option><option value="90">Liechtenstein</option><option value="91">Lithuania</option><option value="92">Luxembourg</option><option value="208">Macau</option><option value="93">Macedonia</option><option value="94">Madagascar</option><option value="95">Malawi</option><option value="96">Malaysia</option><option value="97">Maldives</option><option value="98">Mali</option><option value="99">Malta</option><option value="207">Marshall Islands</option><option value="210">Martinique</option><option value="100">Mauritania</option><option value="212">Mauritius</option><option value="241">Mayotte</option><option value="101">Mexico</option><option value="102">Moldova, Republic of</option><option value="103">Monaco</option><option value="104">Mongolia</option><option value="290">Montenegro</option><option value="294">Montserrat</option><option value="105">Morocco</option><option value="106">Mozambique</option><option value="242">Myanmar</option><option value="107">Namibia</option><option value="108">Nepal</option><option value="109">Netherlands</option><option value="110">Netherlands Antilles</option><option value="213">New Caledonia</option><option value="111">New Zealand</option><option value="112">Nicaragua</option><option value="113">Niger</option><option value="114">Nigeria</option><option value="217">Niue</option><option value="214">Norfolk Island</option><option value="272">North Korea</option><option value="116">Norway</option><option value="117">Oman</option><option value="118">Pakistan</option><option value="222">Palau</option><option value="282">Palestine</option><option value="119">Panama</option><option value="219">Papua New Guinea</option><option value="120">Paraguay</option><option value="121">Peru</option><option value="122">Philippines</option><option value="221">Pitcairn</option><option value="123">Poland</option><option value="124">Portugal</option><option value="126">Qatar</option><option value="315">Republic of Kosovo</option><option value="127">Reunion</option><option value="128">Romania</option><option value="129">Russia</option><option value="130">Rwanda</option><option value="205">Saint Kitts and Nevis</option><option value="206">Saint Lucia</option><option value="324">Saint Martin</option><option value="237">Saint Vincent and the Grenadines</option><option value="132">Samoa (Independent)</option><option value="227">San Marino</option><option value="255">Sao Tome and Principe</option><option value="133">Saudi Arabia</option><option value="134">Senegal</option><option value="326">Serbia</option><option value="135">Seychelles</option><option value="136">Sierra Leone</option><option value="137">Singapore</option><option value="302">Sint Maarten</option><option value="138">Slovakia</option><option value="139">Slovenia</option><option value="223">Solomon Islands</option><option value="140">Somalia</option><option value="141">South Africa</option><option value="257">South Georgia and the South Sandwich Islands</option><option value="142">South Korea</option><option value="311">South Sudan</option><option value="143">Spain</option><option value="144">Sri Lanka</option><option value="293">Sudan</option><option value="146">Suriname</option><option value="225">Svalbard and Jan Mayen Islands</option><option value="147">Swaziland</option><option value="148">Sweden</option><option value="149">Switzerland</option><option value="285">Syria</option><option value="152">Taiwan</option><option value="260">Tajikistan</option><option value="153">Tanzania</option><option value="154">Thailand</option><option value="233">Timor-Leste</option><option value="155">Togo</option><option value="232">Tonga</option><option value="234">Trinidad and Tobago</option><option value="156">Tunisia</option><option value="157">Turkey</option><option value="158">Turkmenistan</option><option value="287">Turks &amp; Caicos Islands</option><option value="159">Uganda</option><option value="161">Ukraine</option><option value="162">United Arab Emirates</option><option value="262" selected>United Kingdom</option><option value="163">Uruguay</option><option value="165">Uzbekistan</option><option value="239">Vanuatu</option><option value="166">Vatican City State (Holy See)</option><option value="167">Venezuela</option><option value="168">Vietnam</option><option value="169">Virgin Islands (British)</option><option value="238">Virgin Islands (U.S.)</option><option value="188">Western Sahara</option><option value="170">Yemen</option><option value="173">Zambia</option><option value="174">Zimbabwe</option></select>
-	</div>
-</div>
-<div class="mc-field-group">
-	<label for="mce-MMERGE6">Desired Kickstart Location </label>
-	<select name="MMERGE6" class="required full-width" id="mce-MMERGE6">
-            <option value=""></option>
-            <option value="Southampton">Southampton</option>
-            <option value="London">London</option>
-            <option value="I cannot attend">I cannot attend</option>
-	</select>
-</div>
-<div class="mc-field-group input-group">
-    <label for="mce-MMERGE7">I would like to submit more than 1 team</label>
-	<select name="MMERGE7" class="required full-width" id="mce-MMERGE7">
-            <option value=""></option>
-            <option value="No">1 team</option>
-            <option value="Yes">2 or more teams</option>
-	</select>
-</div>
-<div id="mergeRow-gdpr" class="mergeRow gdpr-mergeRow content__gdprBlock mc-field-group">
-    <div class="content__gdpr">
-        <p>Student Robotics will use the information you provide on this form to contact you around leading a team at Student Robotics. We will contact you via email.</p>
-        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="gdpr[24613]" tabindex="-1" value="Y"></div>
-    </div>
-    <div class="content__gdprLegal">
-        <p>We use MailChimp as our contacting platform. By clicking below to sign up, you acknowledge that your information will be transferred to MailChimp for processing. Learn more about MailChimp's privacy practices <a href="https://mailchimp.com/legal/" target="_blank">here</a>.</p>
-    </div>
-</div>
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_1af17c2a3426de258620aae46_dd9ef8ad9f" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Sign Up" name="subscribe" id="mc-embedded-subscribe" class="button button-primary full-width"></div>
+      <div class="mc-field-group">
+        <label for="mce-EMAIL">Email Address</label>
+        <input type="email" value="" name="EMAIL" class="required email full-width" id="mce-EMAIL">
+      </div>
+      <div class="mc-field-group">
+        <label for="mce-FNAME">Your First Name</label>
+        <input type="text" value="" name="FNAME" class="" id="mce-FNAME" size="24">
+      </div>
+      <div class="mc-field-group">
+        <label for="mce-LNAME">Your Last Name</label>
+        <input type="text" value="" name="LNAME" class="" id="mce-LNAME" size="24">
+      </div>
+      <div class="mc-field-group">
+        <label for="mce-MMERGE4">Organisation</label>
+        <p class="explanation">If your team represents a school, or another organisation, enter its name here.</p>
+        <input type="text" value="" name="MMERGE4" class="full-width" id="mce-MMERGE4">
+      </div>
+      <div id="mce-responses" class="clear">
+        <div class="response" id="mce-error-response" style="display:none"></div>
+        <div class="response" id="mce-success-response" style="display:none"></div>
+      </div>
+      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_1af17c2a3426de258620aae46_dd7d04139d" tabindex="-1" value=""></div>
+      <div class="clear">
+        <input class="button button-primary" type="submit" value="Register your interest" name="subscribe" id="mc-embedded-subscribe">
+        <span>or</span>
+        <a class="button" href="mailto:{{ site.emails.teams }}" target="_blank">Speak to someone</a>
+      </div>
     </div>
 </form>
-</div>
-
-<!--End mc_embed_signup-->

--- a/_includes/volunteer-signup.html
+++ b/_includes/volunteer-signup.html
@@ -1,46 +1,23 @@
-<!-- Begin MailChimp Signup Form -->
-<div id="mc_embed_signup">
-  <form action="https://studentrobotics.us12.list-manage.com/subscribe/post?u=1af17c2a3426de258620aae46&amp;id=28b16731d1"
+<form action="//studentrobotics.us12.list-manage.com/subscribe/post?u=1af17c2a3426de258620aae46&amp;id=220e1d8952"
       method="post"
       id="mc-embedded-subscribe-form"
       name="mc-embedded-subscribe-form"
-      class="form form-left show-labels validate"
-      target="_blank"
-      novalidate>
-    <div id="mc_embed_signup_scroll">
-<div class="mc-field-group">
-	<label for="mce-EMAIL">Email Address </label>
-	<input type="email" value="" name="EMAIL" class="required email full-width" id="mce-EMAIL">
-</div>
-<div class="mc-field-group">
-	<label for="mce-FNAME">First Name </label>
-	<input type="text" value="" name="FNAME" class="required full-width" id="mce-FNAME">
-</div>
-<div class="mc-field-group">
-	<label for="mce-LNAME">Last Name </label>
-	<input type="text" value="" name="LNAME" class="required full-width" id="mce-LNAME">
-</div>
-<div class="mc-field-group">
-	<label for="mce-MMERGE3">Location </label>
-	<input type="text" value="" name="MMERGE3" class="full-width" id="mce-MMERGE3">
-</div>
-<div id="mergeRow-gdpr" class="mergeRow gdpr-mergeRow content__gdprBlock mc-field-group">
-    <div class="content__gdpr">
-        <p>Student Robotics will use the information you provide on this form to inform you about volunteering opportunities, as well as discuss specifics around volunteering with you. We do this via email.</p>
-        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="gdpr[6869]" tabindex="-1" value="Y"></div>
+      class="form validate"
+      target="_blank" novalidate>
+  <div id="mc_embed_signup_scroll">
+    <div class="mc-field-group">
+      <label for="mce-EMAIL">Email Address </label>
+      <input type="email" value="" name="EMAIL" class="full-width required email" id="mce-EMAIL" placeholder="Enter your email address">
     </div>
-    <div class="content__gdprLegal">
-        <p>We use MailChimp as our contacting platform. By clicking below to sign up, you acknowledge that your information will be transferred to MailChimp for processing. Learn more about MailChimp's privacy practices <a href="https://mailchimp.com/legal/" target="_blank">here</a>.</p>
+    <div id="mce-responses" class="clear">
+      <div class="response" id="mce-error-response" style="display:none"></div>
+      <div class="response" id="mce-success-response" style="display:none"></div>
     </div>
-</div>
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_1af17c2a3426de258620aae46_28b16731d1" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Sign Up" name="subscribe" id="mc-embedded-subscribe" class="button button-primary full-width"></div>
+    <div style="position: absolute; left: -5000px;" aria-hidden="true">
+      <input type="text" name="b_1af17c2a3426de258620aae46_220e1d8952" tabindex="-1" value="">
     </div>
-  </form>
-</div>
-
-<!--End mc_embed_signup-->
+    <div class="clear">
+      <input class="button button-primary" type="submit" value="Sign up to volunteer" name="subscribe" id="mc-embedded-subscribe" class="button">
+    </div>
+  </div>
+</form>

--- a/_includes/volunteer-signup.html
+++ b/_includes/volunteer-signup.html
@@ -20,4 +20,13 @@
       <input class="button button-primary" type="submit" value="Sign up to volunteer" name="subscribe" id="mc-embedded-subscribe" class="button">
     </div>
   </div>
+  <div id="mergeRow-gdpr" class="mergeRow gdpr-mergeRow content__gdprBlock mc-field-group">
+    <div class="content__gdpr">
+      <p>Student Robotics will use the information you provide on this form to contact you around leading a team at Student Robotics. We will contact you via email.</p>
+      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="gdpr[24613]" tabindex="-1" value="Y"></div>
+    </div>
+    <div class="content__gdprLegal">
+      <p>We use MailChimp as our contacting platform. By clicking below to sign up, you acknowledge that your information will be transferred to MailChimp for processing. Learn more about MailChimp's privacy practices <a href="https://mailchimp.com/legal/" target="_blank">here</a>.</p>
+    </div>
+  </div>
 </form>

--- a/compete.html
+++ b/compete.html
@@ -130,7 +130,7 @@ permalink: /compete/
       <a name="signup"></a><h2>Want to compete?</h2>
       <div class="column m-8-12 m-offset-2-12 text-left">
         <p>
-          Entries for this year's competition are open until the 26th October 2018.
+          Please register your interest below, we'll let you know when formal entries open later this year.
         </p>
         <p class="text-heavy">
           You must be over 18 to run a Student Robotics team and so you must also be over 18 to fill in this form.

--- a/volunteer.html
+++ b/volunteer.html
@@ -70,8 +70,8 @@ permalink: /volunteer/
 <div class="panel">
   <div class="panel-container">
     <div class="panel-fill text-center row">
-      <a name="signup"></a><h2>Want to volunteer?</h2>
-      <div class="column m-8-12 m-offset-2-12 text-left">
+      <div class="column l-6-12 l-offset-3-12">
+        <a name="signup"></a><h2>Want to volunteer?</h2>
         <p>Sign up and we'll keep you updated on volunteering opportunities.</p>
         {% include volunteer-signup.html %}
       </div>


### PR DESCRIPTION
Revert https://github.com/srobo/website/pull/87/ to revert back to year-agnostic signup forms. This affects both volunteer and team leader forms.

I've tested both work locally, and put details into the list i'd expect. 

I appreciate this is almost impossible to reasonably review.

Replaces https://github.com/srobo/website/pull/149