### PR TITLE
Drop HTTPS as part of the move to DigitalOcean

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,11 @@ the reverse proxy is working before you commit. To do this, do the following:
     $ rake run
     ```
 
-5. Visit <https://localhost:443> in a browser (adjust the port as needed if you
+5. Visit <http://localhost> in a browser (adjust the port as needed if you
    edited it), and confirm that you see a copy of the SR website (also check that
    you didn't get redirect to the real one!)
 
 6. Make your changes to the [`nginx.conf`](_env/nginx.conf)
-
 
 7. Get those changes into the container and reload nginx:
     ``` shell

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ task :build => [:dependencies] do
   sh('docker build --tag srobo/website .')
 end
 
-task :run => [:cert, :build] do
+task :run => [:build] do
   sh('docker run --rm -p 80:80 --name srobo srobo/website')
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ end
 task :cert => ['_secrets/cert.pem', '_secrets/key.pem']
 
 task :run => [:cert, :build] do
-  sh('docker run --rm -p 80:80 -p 443:443 -v $(pwd)/_secrets:/etc/secrets --name srobo srobo/website')
+  sh('docker run --rm -p 80:80 --name srobo srobo/website')
 end
 
 task :deploy do

--- a/Rakefile
+++ b/Rakefile
@@ -20,16 +20,6 @@ task :build => [:dependencies] do
   sh('docker build --tag srobo/website .')
 end
 
-directory '_secrets'
-
-%W[_secrets/cert.pem _secrets/key.pem].each do |cert_file|
-  file cert_file => [:_secrets] do
-    sh('openssl req -subj \'/CN=studentrobotics.org/O=John Doe/C=GB\' -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout _secrets/key.pem -out _secrets/cert.pem')
-  end
-end
-
-task :cert => ['_secrets/cert.pem', '_secrets/key.pem']
-
 task :run => [:cert, :build] do
   sh('docker run --rm -p 80:80 --name srobo srobo/website')
 end

--- a/_env/kubernetes/deployment.yml
+++ b/_env/kubernetes/deployment.yml
@@ -1,29 +1,20 @@
 ---
+apiVersion: apps/v1
 kind: Deployment
-apiVersion: extensions/v1beta1
 metadata:
-  name: srobo-website
+  name: website
 spec:
+  selector:
+    matchLabels:
+      run: website
   replicas: 1
   template:
     metadata:
       labels:
-        app: website
+        run: website
     spec:
       containers:
-      - name: website
-        image: srobo/website
-        imagePullPolicy: Always
-        ports:
-        - name: http
-          containerPort: 80
-        - name: https
-          containerPort: 443
-        volumeMounts:
-        - name: secrets
-          mountPath: /etc/secrets
-          readOnly: true
-      volumes:
-      - name: secrets
-        secret:
-          secretName: https-keys
+        - name: website
+          image: srobo/website
+          ports:
+            - containerPort: 80

--- a/_env/kubernetes/service.yml
+++ b/_env/kubernetes/service.yml
@@ -2,26 +2,15 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: website
   labels:
-    app: website
-  name: srobo-website
+    run: website
 spec:
+  type: NodePort
   ports:
-  - name: http
-    nodePort: 32056
-    port: 80
-    protocol: TCP
-    targetPort: 80
-  - name: https
-    nodePort: 31167
-    port: 443
-    protocol: TCP
-    targetPort: 443
+    - port: 80
+      nodePort: 30000
+      targetPort: 80
+      protocol: TCP
   selector:
-    app: website
-  type: LoadBalancer
-  loadBalancerIP: 104.155.107.130
-status:
-  loadBalancer:
-    ingress:
-    - ip: 104.155.107.130
+    run: website

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -29,8 +29,8 @@ http {
 
   server {
     listen         80;
-    server_name       localhost;
-    root              /var/www;
+    server_name    localhost;
+    root           /var/www;
 
     proxy_pass_request_headers on;
     proxy_set_header X-Real-IP          $remote_addr;

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -29,20 +29,8 @@ http {
 
   server {
     listen         80;
-    server_name    studentrobotics.org;
-    return         301 https://$server_name$request_uri;
-  }
-
-  server {
-    listen            443 default_server ssl http2;
-    listen            [::]:443 default_server ssl http2 ipv6only=on;
     server_name       localhost;
     root              /var/www;
-
-    ssl_certificate         /etc/secrets/cert.pem;
-    ssl_certificate_key     /etc/secrets/key.pem;
-    ssl_protocols           TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
-    ssl_ciphers             HIGH:!aNULL:!MD5:!RC4:!EXPORT;
 
     proxy_pass_request_headers on;
     proxy_set_header X-Real-IP          $remote_addr;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "dependencies": {
     "brand": {
-      "version": "github:srobo/brand#89ce1d5242167fdea54eb310bb335a7741c0d184",
+      "version": "github:srobo/brand#97bef2a6606b97b60ee625e980d0035ab9845060",
       "from": "github:srobo/brand",
       "dev": true
     }


### PR DESCRIPTION
Hey all,

As part of the certificate expiry problem I've started to move this off Google Cloud and onto DigitalOcean. Like our existing infrastructure, it's still in a container, and there's still a kubernetes cluster.

So the way it's going to work for the time being is that:

* https://studentrobotics.org points to a DigitalOcean load balancer, which balances across all the Kubernetes nodes. Right now there is only one node.
* On each of those nodes the website runs on port 30000.
* The load balancer terminates SSL, the certificate is renewed and managed by DigitalOcean & LetsEncrypt.

There's a working example of everything I've setup so far at https://studentrobotics.co.uk, with a forked Docker image running these changes. I've also got some Terraform code, which provisions the DigitalOcean account and the cluster, coming in another repository.

Next steps will be to pull the website onto some free static hosting, like we do with the docs, and have a separate repository for the reverse proxy.