### PR TITLE
Add an announcement post for SR2020 registration being open

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "spellchecker.language": "en_GB-ise",
     "spellchecker.ignoreWordsList": [
+        "Aldgate",
         "Brockenhurst",
         "Basingstoke",
         "Gordano",
@@ -14,6 +15,7 @@
         "baseurl",
         "blueshirt",
         "blueshirts",
+        "kickstart",
         "Kickstart",
         "Kickstarts",
         "Facebook",

--- a/_posts/2019-09-03-sr2020-registration-open.md
+++ b/_posts/2019-09-03-sr2020-registration-open.md
@@ -1,0 +1,34 @@
+---
+layout: news
+title: Registration opens for Student Robotics 2020
+---
+
+We're excited to announce that registration for the 2020 season of Student
+Robotics is now open!
+
+The competition cycle will start with an expected three kickstart events at
+which the game will be announced and the kits handed out to teams.
+
+While the details for kickstart are not yet available, the events are expected
+to take place on the same weekend in mid-late October and be hosted:
+
+ * in Aldgate, London
+ * in Cambridge
+ * in Southampton
+
+The competition, which will take place over two days in around April 2020, will
+see the robots compete through a league stage and a seeded knockout. As usual,
+the prizes will recognise not only the teams which come top in the knockouts,
+but also those who excel in other ways.
+
+Details of the game and prizes will be revealed at kickstart. Details of the
+kickstart and competition events will be published when they are available.
+We expect to confirm places at the end of September.
+
+If you would like a chance to compete in Student Robotics 2020, please fill in
+the [entry form][entry-form] with the required information. We're expecting to
+run with a similar number of teams to SR2019, so places will go fast.
+
+We look forward to seeing your teams!
+
+[entry-form]: https://docs.google.com/forms/d/e/1FAIpQLSfwfZ-tQz31H4-D81cFSmG2p_ciKPpP88MhtXvPmH05yzNzVQ/viewform


### PR DESCRIPTION
This complements #156 and https://github.com/srobo/team-emails/pull/24 by adding a post which announces that registration is open.