### PR TITLE
Remove references to the removed _secrets directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .jekyll-metadata
 gems
 node_modules
-_secrets
 _site
 npm-debug.log
 

--- a/_config.yml
+++ b/_config.yml
@@ -61,7 +61,6 @@ exclude:
   - _env/
   - gems/
   - node_modules/
-  - _secrets/
   - scripts/
 
 paginate: 3


### PR DESCRIPTION
This was used when this repo's nginx config was doing TLS termination, which is no longer the case.