### PR TITLE
Change link to say 'All events'

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ layout: home
           {% else %}
           <p>There are no upcoming events.</p>
           {% endif %}
-          <a href="{{ '/events/' | prepend: site.baseurl }}">Past events</a>
+          <a href="{{ '/events/' | prepend: site.baseurl }}">All events</a>
         </div>
         <div class="card">
           <h3 class="card-heading">Sponsors</h3>


### PR DESCRIPTION
**Super nit-picky PR alert**

The `/events/` page actually lists all events, rather than just ones in the past.