### PR TITLE
Fix any_events when a cancelled event is the only one

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ layout: home
           {% assign any_events = false %}
           {% for event in site.events %}
           {% comment %}{# Changing this condition? also change it in the below above #}{% endcomment %}
-          {% if event.date > site.time %}
+          {% if event.date > site.time and event.cancelled != true %}
           {% assign any_events = true %}
           {% endif %}
           {% endfor %}

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@ layout: home
           <h3 class="card-heading">Upcoming Events</h3>
           {% assign any_events = false %}
           {% for event in site.events %}
+          {% comment %}{# Changing this condition? also change it in the below above #}{% endcomment %}
           {% if event.date > site.time %}
           {% assign any_events = true %}
           {% endif %}
@@ -52,6 +53,7 @@ layout: home
           {% if any_events %}
           <ul class="event-list">
             {% for event in site.events %}
+            {% comment %}{# Changing this condition? also change it in the loop above #}{% endcomment %}
             {% if event.date > site.time and event.cancelled != true %}
             <li class="event">
               <p class="event-name"><a href="{{ event.url | prepend: site.baseurl }}">{{ event.title }}</a></p>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ layout: home
           <h3 class="card-heading">Upcoming Events</h3>
           {% assign any_events = false %}
           {% for event in site.events %}
-          {% comment %}{# Changing this condition? also change it in the below above #}{% endcomment %}
+          {% comment %}{# Changing this condition? also change it in the loop below #}{% endcomment %}
           {% if event.date > site.time and event.cancelled != true %}
           {% assign any_events = true %}
           {% endif %}


### PR DESCRIPTION
This ensures that if we have a cancelled event as the only future event, we show the proper "There are no upcoming events" message.

Spotted while reviewing the code, I don't think we've ever actually hit this issue.