### PR TITLE
Revert "Work around a bitnami/phpbb bug"

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -46,13 +46,6 @@ http {
       proxy_pass https://patience.studentrobotics.org/forum/;
     }
 
-    # Work around https://github.com/bitnami/bitnami-docker-phpbb/issues/54.
-    # Ideally we'd handle this with a `sub_filter` on patience, but I couldn't
-    # make that work, hence this hack.
-    location /bitnami/phpbb/ {
-      proxy_pass https://patience.studentrobotics.org/bitnami/phpbb/;
-    }
-
     location /trac/ {
       proxy_pass https://saffron.studentrobotics.org/trac/;
     }


### PR DESCRIPTION
This reverts commit be014f7c714297ff5b258aa29f4e46722773df17.

This has been fixed in a better way in the underlying nginx server:
https://github.com/srobo/server-puppet/commit/b0779c5872a776a6c1e8291346b086da0c2669e5