### PR TITLE
Remove proxy workaround for GitHub Pages insecure redirects

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -73,13 +73,6 @@ http {
     location /docs/ {
       proxy_pass       https://srobo.github.io/docs/;
       proxy_set_header Host srobo.github.io;
-      # Work around github.io issuing HTTP (not HTTPS) redirects when
-      # redirecting to cannonical forms of urls. For example, given the url
-      # "https://studentrobotics.org/docs/programming", which we proxy to
-      # "https://srobo.github.io/docs/programming", it issues a redirect to
-      # "http://srobo.github.io/docs/programming/" which we would otherwise
-      # expose to the client, sending them away from our domain.
-      proxy_redirect   http://srobo.github.io/docs/ /docs/;
     }
 
     location /userman/ {
@@ -107,8 +100,6 @@ http {
     # location = / {
     #   proxy_pass       https://srobo.github.io/competition-website/comp/;
     #   proxy_set_header Host srobo.github.io;
-    #   # Work around github.io redirect issue (see above)
-    #   proxy_redirect   http://srobo.github.io/competition-website/comp/ /;
     #
     #   sub_filter "/competition-website/comp/" "/comp/";
     #   sub_filter_once off;
@@ -122,8 +113,6 @@ http {
     location /comp/ {
       proxy_pass       https://srobo.github.io/competition-website/comp/;
       proxy_set_header Host srobo.github.io;
-      # Work around github.io redirect issue (see above)
-      proxy_redirect   http://srobo.github.io/competition-website/comp/ /comp/;
 
       sub_filter "/competition-website/comp/" "/comp/";
       sub_filter_once off;
@@ -138,8 +127,6 @@ http {
     location /competition-website/ {
       proxy_pass       https://srobo.github.io/competition-website/;
       proxy_set_header Host srobo.github.io;
-      # Work around github.io redirect issue (see above)
-      proxy_redirect   http://srobo.github.io/competition-website/ /competition-website/;
     }
 
     # Disable custom media consent endpoint
@@ -158,8 +145,6 @@ http {
     location /style/ {
       proxy_pass       https://srobo.github.io/style/;
       proxy_set_header Host srobo.github.io;
-      # Work around github.io redirect issue (see above)
-      proxy_redirect   http://srobo.github.io/style/ /style/;
     }
 
     rewrite ^/schools/how_to_enter /compete redirect;


### PR DESCRIPTION
It seems that GitHub have fixed this; certainly testing locally with a build of the proxy I now get the correct behaviour without these lines (and ironically now get the wrong behaviour with them).

Review note: yes, I realise that ideally we'd be moving to https://github.com/srobo/reverse-proxy, however since we don't seem to have done that yet, let's ship this here and I'll replay it there.