### PR TITLE
Add Tech Days to the announcement

### DIFF
--- a/_events/sr2020/london-tech-day-february.md
+++ b/_events/sr2020/london-tech-day-february.md
@@ -1,0 +1,50 @@
+---
+title: London February Tech Day
+date: 2020-02-29 10:00:00
+layout: event
+type: techday
+location: Thread, Whitechapel
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They're also an opportunity to see how other
+teams are doing or get more direct help with your robots.
+
+We provide a space for you to work in, with power and internet access, as well
+as volunteers able to help you with your kits and hands-on guidance with your
+robots.
+
+London Tech Days will only run of there is sufficient interest. Spaces are
+limited to six teams, so be sure to [let us know][tech-day-signup] by Wednesday
+19th February 2020 if you'd like to attend.
+
+**Please bring your laptops!**
+
+## Directions
+
+The London Kickstart is being held in the [offices of Thread][venue-map] at:
+
+1 Alie Street,  
+Whitechapel,  
+London,  
+E1 8DE
+
+The easiest way to travel will be by public transport -- Aldgate, Aldgate East
+and Tower Gateway stations are all within a five minute walk, and Liverpool
+Street station is a ten minute walk away. There are also a large number of
+busses which stop nearby.
+
+Upon arrival at reception, please ask for Thread.
+
+## Schedule
+
+| Time  | Info |
+|-------|------|
+| 10:00 | Doors Open. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 13:00 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them. |
+| 17:00 | Finish. |
+
+[venue-map]: https://goo.gl/13LbAL
+[tech-day-signup]: https://forms.gle/vSrzt4o85542MGcv8
+[teams-contact]: mailto:teams@studentrobotics.org

--- a/_events/sr2020/london-tech-day-january.md
+++ b/_events/sr2020/london-tech-day-january.md
@@ -1,0 +1,50 @@
+---
+title: London January Tech Day
+date: 2020-01-25 10:00:00
+layout: event
+type: techday
+location: Thread, Whitechapel
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They're also an opportunity to see how other
+teams are doing or get more direct help with your robots.
+
+We provide a space for you to work in, with power and internet access, as well
+as volunteers able to help you with your kits and hands-on guidance with your
+robots.
+
+London Tech Days will only run of there is sufficient interest. Spaces are
+limited to six teams, so be sure to [let us know][tech-day-signup] by Wednesday
+15th January 2020 if you'd like to attend.
+
+**Please bring your laptops!**
+
+## Directions
+
+The London Kickstart is being held in the [offices of Thread][venue-map] at:
+
+1 Alie Street,  
+Whitechapel,  
+London,  
+E1 8DE
+
+The easiest way to travel will be by public transport -- Aldgate, Aldgate East
+and Tower Gateway stations are all within a five minute walk, and Liverpool
+Street station is a ten minute walk away. There are also a large number of
+busses which stop nearby.
+
+Upon arrival at reception, please ask for Thread.
+
+## Schedule
+
+| Time  | Info |
+|-------|------|
+| 10:00 | Doors Open. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 13:00 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them. |
+| 17:00 | Finish. |
+
+[venue-map]: https://goo.gl/13LbAL
+[tech-day-signup]: https://forms.gle/vSrzt4o85542MGcv8
+[teams-contact]: mailto:teams@studentrobotics.org

--- a/_events/sr2020/london-tech-day-march.md
+++ b/_events/sr2020/london-tech-day-march.md
@@ -1,0 +1,50 @@
+---
+title: London March Tech Day
+date: 2020-03-28 10:00:00
+layout: event
+type: techday
+location: Thread, Whitechapel
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They're also an opportunity to see how other
+teams are doing or get more direct help with your robots.
+
+We provide a space for you to work in, with power and internet access, as well
+as volunteers able to help you with your kits and hands-on guidance with your
+robots.
+
+London Tech Days will only run of there is sufficient interest. Spaces are
+limited to six teams, so be sure to [let us know][tech-day-signup] by Wednesday
+18th March 2020 if you'd like to attend.
+
+**Please bring your laptops!**
+
+## Directions
+
+The London Kickstart is being held in the [offices of Thread][venue-map] at:
+
+1 Alie Street,  
+Whitechapel,  
+London,  
+E1 8DE
+
+The easiest way to travel will be by public transport -- Aldgate, Aldgate East
+and Tower Gateway stations are all within a five minute walk, and Liverpool
+Street station is a ten minute walk away. There are also a large number of
+busses which stop nearby.
+
+Upon arrival at reception, please ask for Thread.
+
+## Schedule
+
+| Time  | Info |
+|-------|------|
+| 10:00 | Doors Open. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 13:00 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them. |
+| 17:00 | Finish. |
+
+[venue-map]: https://goo.gl/13LbAL
+[tech-day-signup]: https://forms.gle/vSrzt4o85542MGcv8
+[teams-contact]: mailto:teams@studentrobotics.org

--- a/_posts/2019-12-17-sr2020-competition-dates-announcement.md
+++ b/_posts/2019-12-17-sr2020-competition-dates-announcement.md
@@ -3,7 +3,9 @@ layout: news
 title: SR2020 Competition Dates Announcement
 ---
 
-We're pleased to announce this year's competition dates.
+We're pleased to announce this year's competition dates and the first Tech Days of 2020.
+
+## Competition Dates
 
 The Student Robotics 2020 competition will be held at Reading University on the 18th and 19th of April 2020.
 
@@ -13,6 +15,31 @@ As usual, we will require attendees to fill out a media consent form.
 
 For more information, please see the competition [event page][competition-event].
 
-See you there!
+We hope to see all the teams and their robots at the Competition!
+
+## Tech Days
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They're also an opportunity to see how other
+teams are doing or get more direct help with their robots.
+
+We provide a space for teams to work in, with power and internet access, as well
+as volunteers able to help with the kits and hands-on guidance for the robots.
+
+We have now confirmed the dates of some of the Tech Days in 2020.
+These will be in Thread's offices at 1 Alie Street in London, on the following
+Saturdays next year:
+
+ * [25 January 2020]({{ site.baseurl }}/events/sr2020/london-tech-day-january/)
+ * [29 February 2020]({{ site.baseurl }}/events/sr2020/london-tech-day-february/)
+ * [28 March 2020]({{ site.baseurl }}/events/sr2020/london-tech-day-march/)
+
+The London Tech Days will only run if there is sufficient interest, so please do
+let us know if you'd like to attend. The deadlines for each are the Wednesday 10
+days ahead of the event.
+
+[Sign up to attend a Tech Day](https://forms.gle/vSrzt4o85542MGcv8)
+
+We expect to confirm more Tech Days at other venues early in the New Year.
 
 [competition-event]: {{ site.baseurl }}/events/sr2020/competition/


### PR DESCRIPTION
Note: this also merges `master` so that the links are valid, but looks like a bigger diff. Do ignore the tech day events -- they're already live (via #186).

This extends #187.