### PR TITLE
Serve the runbook from `/runbook/`

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -152,7 +152,6 @@ http {
       proxy_set_header Host srobo.github.io;
     }
     
-
     rewrite ^/schools/how_to_enter /compete redirect;
     rewrite ^/about/how_to_help    /volunteer redirect;
     rewrite ^/about/contactus      /contact redirect;

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -146,6 +146,12 @@ http {
       proxy_pass       https://srobo.github.io/style/;
       proxy_set_header Host srobo.github.io;
     }
+    
+    location /runbook/ {
+      proxy_pass       https://srobo.github.io/runbook/;
+      proxy_set_header Host srobo.github.io;
+    }
+    
 
     rewrite ^/schools/how_to_enter /compete redirect;
     rewrite ^/about/how_to_help    /volunteer redirect;


### PR DESCRIPTION
Enabled by https://github.com/srobo/runbook/pull/75

Replaces https://github.com/srobo/infrastructure/pull/6