### PR TITLE
More competition information

### DIFF
--- a/_events/sr2020/competition.md
+++ b/_events/sr2020/competition.md
@@ -8,7 +8,7 @@ location: Reading University
 
 The Student Robotics Competition marks the ultimate stage of SR2020, showcasing the months of preparation. Our teams will work hard to push their robots to the limit and quickly make repairs between league matches. We will finish the weekend with the finals where the best bots will be named victorious.
 
-More information will be released soon.
+Keep an eye on this page for updates as more information becomes available.
 
 ## Schedule
 

--- a/_events/sr2020/competition.md
+++ b/_events/sr2020/competition.md
@@ -70,5 +70,24 @@ Reading
 RG6 6UR  
 United Kingdom  
 
+## Parking
+
+There will be free parking in [Reading University campus car-park **P4**][car-park-p4].
+
+## Food
+
+There is a Starbucks and a sandwich bar within the venue, which will both be open.
+Alternatively there is a [Co-op on campus][campus-coop] which we expect will also be open.
+
+## Accommodation
+
+Student Robotics are not able to provide any accommodation for competitors,
+however teams often choose to stay near the venue for the competition weekend.
+This enables them to spend more time working on their robot, or just relax on
+the Saturday evening. If you wish to stay in the area, there are a number of
+hotels which may be suitable.
+
 [reading-campus-directions]: https://www.rusu.co.uk/contact/find-us/
 [teams-contact]: mailto:teams@studentrobotics.org
+[car-park-p4]: https://goo.gl/maps/1QEQw67K8V23SPHN9
+[campus-coop]: https://goo.gl/maps/cv6RcfDAJqCyvUC1A

--- a/_events/sr2020/competition.md
+++ b/_events/sr2020/competition.md
@@ -14,6 +14,43 @@ More information will be released soon.
 
 The competition will be held from *Saturday 18th April* until *Sunday 19th April*.
 
+### Day 1 - 18th April, 2020
+
+Saturday begins with a briefing on the rules and general struture of the
+weekend, followed by the start of the league matches will start. The league
+matches offer teams a chance to prove their robot against up to three others,
+earn points which will seed the knockouts and improve their robots as they go.
+
+| Time  | Activity                         |
+|-------|----------------------------------|
+| 9:30  | Doors open                       |
+| 10:45 | Introduction and safety briefing |
+| 11:15 | League matches                   |
+| 12:15 | Lunch                            |
+| 13:00 | League matches                   |
+| 17:30 | End of day                       |
+
+### Day 2 - 19th April, 2020
+
+On Sunday morning, the league matches will continue. Once these have concluded,
+we will begin knockout matches, the order of which is determined a teams'
+position in the league. The remaining teams will compete in the finals, followed
+by the awards for the winning teams.
+
+| Time  | Activity                |
+|-------|-------------------------|
+| 9:30  | Doors open              |
+| 10:20 | League matches          |
+| 12:00 | Lunch                   |
+| 13:00 | League matches          |
+| 13:45 | Competition Photo       |
+| 14:20 | Knockouts               |
+| 16:10 | Prize ceremony          |
+| 16:30 | Kit return              |
+| 17:15 | End of day              |
+
+*Please note: exact timings are subject to change on the day.*
+
 ## Tickets and Media Consent
 
 Competitors need to bring along a ticket to be allowed entry. Anyone under the age of 18 must be accompanied by an adult.

--- a/_events/sr2020/competition.md
+++ b/_events/sr2020/competition.md
@@ -17,9 +17,9 @@ The competition will be held from *Saturday 18th April* until *Sunday 19th April
 ### Day 1 - 18th April, 2020
 
 Saturday begins with a briefing on the rules and general struture of the
-weekend, followed by the start of the league matches will start. The league
-matches offer teams a chance to prove their robot against up to three others,
-earn points which will seed the knockouts and improve their robots as they go.
+weekend, followed by the start of the league matches. The league matches offer
+teams a chance to prove their robot against up to three others, earn points
+which will seed the knockouts and improve their robots as they go.
 
 | Time  | Activity                         |
 |-------|----------------------------------|


### PR DESCRIPTION
* Add initial day schedules based on an amalgamation of the schedules in https://github.com/srobo/tasks/issues/436#issuecomment-592980117, with a slight bias towards quoting the earlier times for most things
* Add information about competition parking food & accommodation

We can definitely make these prettier, however the aim here is to get this out quickly now we've realise that the page is as bare as it is.