### PR TITLE
Separate COVID-19 update into permanent page and announcing post

### DIFF
--- a/_posts/2020-03-11-sr2020-covid-19-updates.md
+++ b/_posts/2020-03-11-sr2020-covid-19-updates.md
@@ -3,45 +3,10 @@ layout: news
 title: COVID-19 Coronavirus Student Robotics Updates
 ---
 
-As you will be aware, the COVID-19 situation is quickly evolving, having recently been delcared a pandemic. 
-Many large events are being cancelled and we want to be public about how we are responding to the latest news.
+As you will be aware, the COVID-19 situation is quickly evolving, having recently been delcared a pandemic. Many large events are being cancelled and we want to be public about how we are responding to the latest news.
 
-## The Competition
+We currently intend to have the competition on the 18th and 19th April 2020 as planned, however are actively and carefully considering whether this needs to change. We will be contacting teams about our decision next week. We will also publish this on the Student Robotics website.
 
-At the time of writing, we still intend to have the competition on the 18th and 19th April 2020, however are actively and carefully considering whether this needs to change.
+To improve transparency about the situation and what Student Robotics is doing, we've created a [COVID-19 updates page]({{ site.baseurl }}/covid-19/).
 
-We will be contacting teams about our decision next week. We will also publish this on the Student Robotics website.
-
-Considering this is an event for minors, we will be taking decisions with an abundance of caution. 
-
-We are in contact with Reading University Students' Union who are continually reviewing the situation, and mitigating the risks associated with Coronavirus.
-
-### In the case of the competition going ahead
-
-We will be briefing all volunteers and attendees about best hygiene practices, both in advance and on the day, ensuring they're followed throughout the competition. 
-
-We expect everyone attending the competition to follow the [guidelines][phe-guidelines] on COVID-19 from Public Health England.
-
-### In the case of the competition being postponed
-
-We are considering weekends in late June / early July as alternatives for the competition. 
-We will be surveying team leaders to ensure we select the most appropriate date.
-
-## Tech Days
-
-At the time of writing, we still intend to run the scheduled Tech Day. However, we will contact all teams as soon as possible should this be cancelled.
-
-In the event of the competition being postponed, all planned Tech Days will be cancelled. 
-
-The [forum][forum] is still a great place to get help from blueshirts and other teams, in addition to showing off your progress!
-
-If you are looking for more in-depth support from blueshirts, you can [email us][teams-email] to request remote mentoring.
-
-
-If you or your school has any questions about our handling of the event, please don't hesitate to contact us at teams@studentrobotics.org.
-
-We will keep this page updated with new information as it becomes available.
-
-[phe-guidelines]: https://www.gov.uk/government/publications/guidance-to-educational-settings-about-covid-19/guidance-to-educational-settings-about-covid-19
-[forum]: https://studentrobotics.org/forum/
-[teams-email]: mailto:teams@studentrobotics.org
+If you or your school has any questions about our handling of the event, please don't hesitate to [contact us](mailto:competition-team@studentrobotics.org).

--- a/covid-19.md
+++ b/covid-19.md
@@ -1,0 +1,41 @@
+---
+layout: news
+title: COVID-19 Updates
+date: 2020-03-11
+---
+
+We will keep this page updated with new information as it becomes available.
+
+Last updated: {{ page.date | date: "%e %B %Y" }}.
+
+## The Competition
+
+**We currently intend to have the competition on the 18th and 19th April 2020 as planned**, however are actively and carefully considering whether this needs to change.
+
+Considering this is an event for minors, we will be taking decisions with an abundance of caution.
+
+We are in contact with Reading University Students' Union who are continually reviewing the situation, and mitigating the risks associated with Coronavirus.
+
+### In the case of the competition going ahead
+
+We will be briefing all volunteers and attendees about best hygiene practices, both in advance and on the day, ensuring they're followed throughout the competition.
+
+We expect everyone attending the competition to follow the [guidelines][phe-guidelines] on COVID-19 from Public Health England.
+
+### In the case of the competition being postponed
+
+We are considering weekends in late June / early July as alternatives for the competition. We will be surveying team leaders to ensure we select the most appropriate date.
+
+## Tech Days
+
+We still intend to run scheduled Tech Days, However we will contact all teams as soon as possible should this change.
+
+In the event of the competition being postponed, all planned Tech Days will be cancelled.
+
+The [forum][forum] is still a great place to get help from blueshirts and other teams, in addition to showing off your progress!
+
+If you are looking for more in-depth support from blueshirts, you can [email us][teams-email] to request remote mentoring.
+
+[phe-guidelines]: https://www.gov.uk/government/publications/guidance-to-educational-settings-about-covid-19/guidance-to-educational-settings-about-covid-19
+[forum]: https://studentrobotics.org/forum/
+[teams-email]: mailto:teams@studentrobotics.org


### PR DESCRIPTION
This creates a new page (`/covid-19/`), which doesn't appear in any nav. The previous post still exists, but is thinned out to simply point towards the new page.

I've done a tiny bit of cleaning around the content, so it reads more like an information page rather than a blog post, but besides that everything is the same

(Unfortunately the diff doesn't make this the most obvious)