### PR TITLE
Add date to covid-19 news post

### DIFF
--- a/_posts/2020-03-11-sr2020-covid-19-updates.md
+++ b/_posts/2020-03-11-sr2020-covid-19-updates.md
@@ -1,6 +1,7 @@
 ---
 layout: news
 title: COVID-19 Coronavirus Student Robotics Updates
+date: 2020-03-11
 ---
 
 As you will be aware, the COVID-19 situation is quickly evolving, having recently been delcared a pandemic. Many large events are being cancelled and we want to be public about how we are responding to the latest news.


### PR DESCRIPTION
I think moving the date off this page stopped it being shown in the newsfeed