### PR TITLE
Cancel the London Tech Day

### DIFF
--- a/_events/sr2020/london-tech-day-march.md
+++ b/_events/sr2020/london-tech-day-march.md
@@ -3,7 +3,8 @@ title: London March Tech Day
 date: 2020-03-28 10:00:00
 layout: event
 type: techday
-location: To be confirmed
+location: n/a
+cancelled: true
 ---
 
 Tech Days are opportunities for teams to spend a whole day working on their
@@ -14,25 +15,6 @@ We provide a space for you to work in, with power and internet access, as well
 as volunteers able to help you with your kits and hands-on guidance with your
 robots.
 
-London Tech Days will only run of there is sufficient interest. Spaces are
-limited to six teams, so be sure to [let us know][tech-day-signup] by Wednesday
-18th March 2020 if you'd like to attend.
-
-**Please bring your laptops!**
-
-## Directions
-
-The location of this Tech Day is still being finalised, we'll update this page
-once we have more information.
-
-## Schedule
-
-| Time  | Info |
-|-------|------|
-| 10:00 | Doors Open. |
-| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
-| 13:00 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them. |
-| 17:00 | Finish. |
+**Due to unavailability of the planned venue this Tech Day will not be running.**
 
 [tech-day-signup]: https://forms.gle/vSrzt4o85542MGcv8
-[teams-contact]: mailto:teams@studentrobotics.org


### PR DESCRIPTION
This is due to ongoing work in Thread's offices meaning they are unavailable for events. At this point it seems unlikely that we will find an alternative venue in time.

I have closed the Tech Day signup form to with a message that there aren't any more Tech Days planned this year.