### PR TITLE
Rewrite links in the calendar and posts feeds

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -171,7 +171,7 @@ http {
 
       sub_filter "/website/" "/";
       sub_filter_once off;
-      sub_filter_types text/css; # in addition to text/html
+      sub_filter_types application/xml text/calendar text/css; # in addition to text/html
       sub_filter_last_modified on;
 
       # Tell GitHub that we want these pages to be sent to us uncompressed

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -146,12 +146,12 @@ http {
       proxy_pass       https://srobo.github.io/style/;
       proxy_set_header Host srobo.github.io;
     }
-    
+
     location /runbook/ {
       proxy_pass       https://srobo.github.io/runbook/;
       proxy_set_header Host srobo.github.io;
     }
-    
+
     rewrite ^/schools/how_to_enter /compete redirect;
     rewrite ^/about/how_to_help    /volunteer redirect;
     rewrite ^/about/contactus      /contact redirect;


### PR DESCRIPTION
Since at least the move to separate proxying, these feeds have included `/website/` in the urls they contain, which makes the links not work.

This fixes that by adding the relevant content types to the proxy's rewrite filter.

I'll copy this over to https://github.com/srobo/reverse-proxy once merged.