### PR TITLE
Hide srcomp for now while the machine doesn't exist

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -95,9 +95,9 @@ http {
       proxy_pass https://patience.studentrobotics.org/robogit-ro/;
     }
 
-    location /comp-api/ {
-      proxy_pass https://srcomp.studentrobotics.org/comp-api/;
-    }
+    # location /comp-api/ {
+    #   proxy_pass https://srcomp.studentrobotics.org/comp-api/;
+    # }
 
     # During the competition we un-comment this block to override the homepage
     # with the comeptition-specific one


### PR DESCRIPTION
It would seem that the latest `nginx` image requires that the upstreams all exist before it will boot.

You probably want to test this alongside #238.