### PR TITLE
Localise event times

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ links:
   compete: //goo.gl/forms/XOuwyvId0JiTP7cq1
   volunteer: //docs.google.com/forms/d/1MIGf3P30dw0QAtP8OkxK2v7VRDEAN_54JoZHCVMbqDY/viewform
 
-timezone: Etc/GMT
+timezone: Europe/London
 
 emails:
   teams: teams@studentrobotics.org

--- a/_events/sr2017/bristol-kickstart.md
+++ b/_events/sr2017/bristol-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Bristol Kickstart
-date: 2016-10-15 10:00:00
+date: 2016-10-15 10:00:00 Europe/London
 layout: event
 type: kickstart
 location: Bristol University

--- a/_events/sr2017/bristol-tech-day-february.md
+++ b/_events/sr2017/bristol-tech-day-february.md
@@ -1,6 +1,6 @@
 ---
 title: Bristol February Tech Day
-date: 2017-02-25 10:00:00
+date: 2017-02-25 10:00:00 Europe/London
 layout: event
 type: techday
 location: Bristol University

--- a/_events/sr2017/bristol-tech-day-march.md
+++ b/_events/sr2017/bristol-tech-day-march.md
@@ -1,6 +1,6 @@
 ---
 title: Bristol March Tech Day
-date: 2017-03-18 10:00:00
+date: 2017-03-18 10:00:00 Europe/London
 layout: event
 type: techday
 location: Bristol University

--- a/_events/sr2017/competition.md
+++ b/_events/sr2017/competition.md
@@ -1,6 +1,6 @@
 ---
 title: Competition
-date: 2017-04-01 09:00:00
+date: 2017-04-01 09:00:00 Europe/London
 layout: event
 type: competition
 location: Newbury Racecourse

--- a/_events/sr2017/oxford-kickstart.md
+++ b/_events/sr2017/oxford-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Oxford Kickstart
-date: 2016-10-15 10:00:00
+date: 2016-10-15 10:00:00 Europe/London
 layout: event
 type: kickstart
 location: The Kings Centre

--- a/_events/sr2017/southampton-kickstart.md
+++ b/_events/sr2017/southampton-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton Kickstart
-date: 2016-10-15 10:00:00
+date: 2016-10-15 10:00:00 Europe/London
 layout: event
 type: kickstart
 location: Southampton University

--- a/_events/sr2017/southampton-tech-day-december.md
+++ b/_events/sr2017/southampton-tech-day-december.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton December Tech Day
-date: 2016-12-17 09:00:00
+date: 2016-12-17 09:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2017/southampton-tech-day-february.md
+++ b/_events/sr2017/southampton-tech-day-february.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton February Tech Day
-date: 2017-2-18 10:00:00
+date: 2017-02-18 10:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2017/southampton-tech-day-january.md
+++ b/_events/sr2017/southampton-tech-day-january.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton January Tech Day
-date: 2017-01-28 09:00:00
+date: 2017-01-28 09:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2017/southampton-tech-day-march.md
+++ b/_events/sr2017/southampton-tech-day-march.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton March Tech Day
-date: 2017-03-25 10:00:00
+date: 2017-03-25 10:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2019/competition.md
+++ b/_events/sr2019/competition.md
@@ -1,6 +1,6 @@
 ---
 title: Competition
-date: 2019-04-06 9:00:00
+date: 2019-04-06 09:00:00 Europe/London
 layout: event
 type: competition
 location: Southampton University

--- a/_events/sr2019/london-kickstart.md
+++ b/_events/sr2019/london-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: London Kickstart
-date: 2018-11-10 10:00:00
+date: 2018-11-10 10:00:00 Europe/London
 layout: event
 type: kickstart
 location: Thread, Whitechapel

--- a/_events/sr2019/london-tech-day-december.md
+++ b/_events/sr2019/london-tech-day-december.md
@@ -1,6 +1,6 @@
 ---
 title: London December Tech Day
-date: 2018-12-15 10:00:00
+date: 2018-12-15 10:00:00 Europe/London
 layout: event
 type: techday
 location: Thread, Whitechapel

--- a/_events/sr2019/london-tech-day-february.md
+++ b/_events/sr2019/london-tech-day-february.md
@@ -1,6 +1,6 @@
 ---
 title: London February Tech Day
-date: 2019-02-09 10:00:00
+date: 2019-02-09 10:00:00 Europe/London
 layout: event
 type: techday
 location: Thread, Whitechapel

--- a/_events/sr2019/london-tech-day-march.md
+++ b/_events/sr2019/london-tech-day-march.md
@@ -1,6 +1,6 @@
 ---
 title: London March Tech Day
-date: 2019-03-09 10:00:00
+date: 2019-03-09 10:00:00 Europe/London
 layout: event
 type: techday
 location: Thread, Whitechapel

--- a/_events/sr2019/southampton-kickstart.md
+++ b/_events/sr2019/southampton-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton Kickstart
-date: 2018-11-10 10:00:00
+date: 2018-11-10 10:00:00 Europe/London
 layout: event
 type: kickstart
 location: Southampton University

--- a/_events/sr2019/southampton-tech-day-december.md
+++ b/_events/sr2019/southampton-tech-day-december.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton December Tech Day
-date: 2018-12-15 10:00:00
+date: 2018-12-15 10:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2019/southampton-tech-day-february.md
+++ b/_events/sr2019/southampton-tech-day-february.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton February Tech Day
-date: 2019-02-09 10:00:00
+date: 2019-02-09 10:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2019/southampton-tech-day-march.md
+++ b/_events/sr2019/southampton-tech-day-march.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton March Tech Day
-date: 2019-03-09 10:00:00
+date: 2019-03-09 10:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2020/cambridge-kickstart.md
+++ b/_events/sr2020/cambridge-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Cambridge Kickstart
-date: 2019-10-26 10:00:00
+date: 2019-10-26 10:00:00 Europe/London
 layout: event
 type: kickstart
 location: University of Cambridge

--- a/_events/sr2020/competition.md
+++ b/_events/sr2020/competition.md
@@ -3,7 +3,7 @@ title: Competition
 layout: event
 type: competition
 location: n/a
-date: 2020-07-04 09:00:00
+date: 2020-07-04 09:00:00 Europe/London
 cancelled: true
 ---
 

--- a/_events/sr2020/london-kickstart.md
+++ b/_events/sr2020/london-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: London Kickstart
-date: 2019-10-26 10:00:00
+date: 2019-10-26 10:00:00 Europe/London
 layout: event
 type: kickstart
 location: Thread, Whitechapel

--- a/_events/sr2020/london-tech-day-february.md
+++ b/_events/sr2020/london-tech-day-february.md
@@ -1,6 +1,6 @@
 ---
 title: London February Tech Day
-date: 2020-02-29 10:00:00
+date: 2020-02-29 10:00:00 Europe/London
 layout: event
 type: techday
 location: Thread, Whitechapel

--- a/_events/sr2020/london-tech-day-january.md
+++ b/_events/sr2020/london-tech-day-january.md
@@ -1,6 +1,6 @@
 ---
 title: London January Tech Day
-date: 2020-01-25 10:00:00
+date: 2020-01-25 10:00:00 Europe/London
 layout: event
 type: techday
 location: Thread, Whitechapel

--- a/_events/sr2020/london-tech-day-march.md
+++ b/_events/sr2020/london-tech-day-march.md
@@ -1,6 +1,6 @@
 ---
 title: London March Tech Day
-date: 2020-03-28 10:00:00
+date: 2020-03-28 10:00:00 Europe/London
 layout: event
 type: techday
 location: n/a

--- a/_events/sr2020/london-tech-day-november.md
+++ b/_events/sr2020/london-tech-day-november.md
@@ -1,6 +1,6 @@
 ---
 title: London November Tech Day
-date: 2019-11-30 10:00:00
+date: 2019-11-30 10:00:00 Europe/London
 layout: event
 type: techday
 location: Thread, Whitechapel

--- a/_events/sr2020/southampton-kickstart.md
+++ b/_events/sr2020/southampton-kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton Kickstart
-date: 2019-10-26 10:00:00
+date: 2019-10-26 10:00:00 Europe/London
 layout: event
 type: kickstart
 location: University of Southampton

--- a/_events/sr2020/southampton-tech-day-february.md
+++ b/_events/sr2020/southampton-tech-day-february.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton February Tech Day
-date: 2020-02-08 10:00:00
+date: 2020-02-08 10:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2020/southampton-tech-day-march.md
+++ b/_events/sr2020/southampton-tech-day-march.md
@@ -1,6 +1,6 @@
 ---
 title: Southampton March Tech Day
-date: 2020-03-07 10:00:00
+date: 2020-03-07 10:00:00 Europe/London
 layout: event
 type: techday
 location: Southampton University

--- a/_events/sr2020/virtual-competition-knockouts.md
+++ b/_events/sr2020/virtual-competition-knockouts.md
@@ -1,6 +1,6 @@
 ---
 title: Virtual Competition Knockouts and Final
-date: 2020-07-25 15:00:00
+date: 2020-07-25 15:00:00 Europe/London
 layout: event
 type: competition
 location: Online

--- a/_events/sr2020/virtual-competition-league-1.md
+++ b/_events/sr2020/virtual-competition-league-1.md
@@ -1,6 +1,6 @@
 ---
 title: Virtual Competition League Session 1
-date: 2020-07-11 15:00:00
+date: 2020-07-11 15:00:00 Europe/London
 layout: event
 type: competition
 location: Online

--- a/_events/sr2020/virtual-competition-league-2.md
+++ b/_events/sr2020/virtual-competition-league-2.md
@@ -1,6 +1,6 @@
 ---
 title: Virtual Competition League Session 2
-date: 2020-07-12 15:00:00
+date: 2020-07-12 15:00:00 Europe/London
 layout: event
 type: competition
 location: Online

--- a/_events/sr2020/virtual-competition-league-3.md
+++ b/_events/sr2020/virtual-competition-league-3.md
@@ -1,6 +1,6 @@
 ---
 title: Virtual Competition League Session 3
-date: 2020-07-18 15:00:00
+date: 2020-07-18 15:00:00 Europe/London
 layout: event
 type: competition
 location: Online

--- a/_events/sr2020/virtual-competition-league-4.md
+++ b/_events/sr2020/virtual-competition-league-4.md
@@ -1,6 +1,6 @@
 ---
 title: Virtual Competition League Session 4
-date: 2020-07-19 15:00:00
+date: 2020-07-19 15:00:00 Europe/London
 layout: event
 type: competition
 location: Online

--- a/_events/sr2021/kickstart.md
+++ b/_events/sr2021/kickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Kickstart
-date: 2020-11-21 13:00:00
+date: 2020-11-21 13:00:00 Europe/London
 layout: event
 type: kickstart
 location: Student Robotics' YouTube Channel

--- a/_includes/datetime.html
+++ b/_includes/datetime.html
@@ -1,10 +1,20 @@
-{% if include.event.time_tbc %}
-  {% assign date_format = include.date_only_format %}
-{% else %}
-  {% assign date_format = include.datetime_format %}
-{% endif %}
 {% if include.event.cancelled %}
-  <s>{{ include.event.date | date: date_format }}</s>
+  {% assign cancelled = 'style="text-decoration: line-through;"' %}
+{% endif %}
+{% if include.event.time_tbc %}
+  <time
+    {{ cancelled }}
+    datetime="{{ include.event.date | date:'%F' }}"
+    title="{{ include.event.date | date:'%a, %d %b %Y' }}"
+  >
+    {{ include.event.date | date:include.date_only_format }}
+  </time>
 {% else %}
-  {{ include.event.date | date: date_format }}
+  <time
+    {{ cancelled }}
+    datetime="{{ include.event.date | date_to_xmlschema }}"
+    title="{{ include.event.date | date_to_rfc822 }}"
+  >
+    {{ include.event.date | date:include.datetime_format }}
+  </time>
 {% endif %}

--- a/_includes/datetime.html
+++ b/_includes/datetime.html
@@ -1,0 +1,10 @@
+{% if include.event.time_tbc %}
+  {% assign date_format = include.date_only_format %}
+{% else %}
+  {% assign date_format = include.datetime_format %}
+{% endif %}
+{% if include.event.cancelled %}
+  <s>{{ include.event.date | date: date_format }}</s>
+{% else %}
+  {{ include.event.date | date: date_format }}
+{% endif %}

--- a/_includes/datetime.html
+++ b/_includes/datetime.html
@@ -12,6 +12,7 @@
 {% else %}
   <time
     {{ cancelled }}
+    class="time-span"
     datetime="{{ include.event.date | date_to_xmlschema }}"
     title="{{ include.event.date | date_to_rfc822 }}"
   >

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -1,4 +1,5 @@
 <script src="{{ '/js/main.js' | prepend: site.baseurl }}"></script>
+<script src="{{ '/js/localise-times.js' | prepend: site.baseurl }}"></script>
 
 {% if site.user_tracking %}
 <!-- Piwik -->

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -11,18 +11,13 @@ layout: page
     <div class="column l-4-12">
       <div class="card thin-card">
         <ul class="detail-list">
-          {% if page.time_tbc %}
-            {% assign date_format = '%e %B %Y <small style="opacity: 70%;">(time <abbr title="To be confirmed">TBC</abbr>)</small>' %}
-          {% else %}
-            {% assign date_format = '%e %B %Y at %l%P' %}
-          {% endif %}
           <li>
             <i class="fa fa-fw fa-clock-o" aria-hidden="true"></i>
-            {% if page.cancelled %}
-              <s>{{ page.date | date: date_format }}</s>
-            {% else %}
-              {{ page.date | date: date_format }}
-            {% endif %}
+            {% comment %}
+            {# Changing the format here? Also change the event page and the localise_times function #}
+            {% endcomment %}
+            {% assign date_only_format = '%e %B %Y <small style="opacity: 70%;">(time <abbr title="To be confirmed">TBC</abbr>)</small>' %}
+            {% include datetime.html date_only_format=date_only_format datetime_format='%e %B %Y at %l%P' event=page %}
           </li>
           <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ page.location }}</li>
         </ul>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -16,7 +16,7 @@ layout: page
             {% comment %}
             {# Changing the format here? Also change the event page and the localise_times function #}
             {% endcomment %}
-            {% assign date_only_format = '%e %B %Y <small style="opacity: 70%;">(time <abbr title="To be confirmed">TBC</abbr>)</small>' %}
+            {% assign date_only_format = '%e %B %Y <small class="muted">(time <abbr title="To be confirmed">TBC</abbr>)</small>' %}
             {% include datetime.html date_only_format=date_only_format datetime_format='%e %B %Y at %l%P' event=page %}
           </li>
           <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ page.location }}</li>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -34,3 +34,10 @@ layout: page
     </div>
   </div>
 </div>
+
+<script type="text/javascript" defer>
+  // function is defined in js/localise-times.js
+  window.addEventListener('load', function() {
+    localise_times('{{ site.timezone }}');
+  });
+</script>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -16,11 +16,14 @@ layout: page
           {% else %}
             {% assign date_format = '%e %B %Y at %l%P' %}
           {% endif %}
-          {% if page.cancelled %}
-            <li><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i> <s>{{ page.date | date: date_format }}</s></li>
-          {% else %}
-            <li><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i> {{ page.date | date: date_format }}</li>
-          {% endif %}
+          <li>
+            <i class="fa fa-fw fa-clock-o" aria-hidden="true"></i>
+            {% if page.cancelled %}
+              <s>{{ page.date | date: date_format }}</s>
+            {% else %}
+              {{ page.date | date: date_format }}
+            {% endif %}
+          </li>
           <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ page.location }}</li>
         </ul>
       </div>

--- a/_sass/events.scss
+++ b/_sass/events.scss
@@ -69,3 +69,7 @@ ul.event-listing {
 .tag.tag-competition, .tag.tag-kickstart {
   background: $sr-orange;
 }
+
+.muted {
+  opacity: 70%;
+}

--- a/events.html
+++ b/events.html
@@ -34,11 +34,13 @@ permalink: /events/
             {% else %}
               {% assign date_format = '%e %B %Y at %l%P' %}
             {% endif %}
-            {% if event.cancelled %}
-              <div class="column d-12-12 l-3-12"><s>{{ event.date | date: date_format }}</s></div>
-            {% else %}
-              <div class="column d-12-12 l-3-12">{{ event.date | date: date_format }}</div>
-            {% endif %}
+            <div class="column d-12-12 l-3-12">
+              {% if event.cancelled %}
+                <s>{{ event.date | date: date_format }}</s>
+              {% else %}
+                {{ event.date | date: date_format }}
+              {% endif %}
+            </div>
             <div class="column d-12-12 l-4-12">{{ event.location }}</div>
           </li>
           {% endfor %}

--- a/events.html
+++ b/events.html
@@ -29,17 +29,11 @@ permalink: /events/
               <a href="{{ event.url | prepend: site.baseurl }}">{{ event.title }}</a>
             </div>
             <div class="column d-12-12 l-2-12"><span class="tag tag-{{ event.type }}">{{ event.type }}</span></div>
-            {% if event.time_tbc %}
-              {% assign date_format = '%e %B %Y' %}
-            {% else %}
-              {% assign date_format = '%e %B %Y at %l%P' %}
-            {% endif %}
             <div class="column d-12-12 l-3-12">
-              {% if event.cancelled %}
-                <s>{{ event.date | date: date_format }}</s>
-              {% else %}
-                {{ event.date | date: date_format }}
-              {% endif %}
+              {% comment %}
+              {# Changing the format here? Also change the event page and the localise_times function #}
+              {% endcomment %}
+              {% include datetime.html date_only_format='%e %B %Y' datetime_format='%e %B %Y at %l%P' event=event %}
             </div>
             <div class="column d-12-12 l-4-12">{{ event.location }}</div>
           </li>

--- a/events.html
+++ b/events.html
@@ -42,3 +42,10 @@ permalink: /events/
       </div>
   </div>
 </div>
+
+<script type="text/javascript" defer>
+  // function is defined in js/localise-times.js
+  window.addEventListener('load', function() {
+    localise_times('{{ site.timezone }}');
+  });
+</script>

--- a/events.ics
+++ b/events.ics
@@ -7,7 +7,7 @@ METHOD:PUBLISH
 {% assign sorted = site.events | sort: 'date' %}
 {% for event in sorted %}BEGIN:VEVENT
 UID:{{ event.url | prepend: site.baseurl | prepend: site.url }}
-DTSTART{% if event.time_tbc %};VALUE=DATE:{{ event.date | date: "%Y%m%d" }}{% else %}:{{ event.date | date: "%Y%m%dT%H%M%S" }}{% endif %}
+DTSTART;TZID={{ site.timezone }}{% if event.time_tbc %};VALUE=DATE:{{ event.date | date: "%Y%m%d" }}{% else %}:{{ event.date | date: "%Y%m%dT%H%M%S" }}{% endif %}
 DTSTAMP{% if event.time_tbc %};VALUE=DATE:{{ event.date | date: "%Y%m%d" }}{% else %}:{{ event.date | date: "%Y%m%dT%H%M%S" }}{% endif %}
 CLASS:PUBLIC
 DESCRIPTION:See

--- a/js/localise-times.js
+++ b/js/localise-times.js
@@ -31,7 +31,7 @@ function localise_times(site_timezone) {
 
     let parts = formatter.formatToParts(date).map(({ type, value }) => {
       if (type == 'timeZoneName') {
-        value = '<small style="opacity: 70%;">' + value + "</small>";
+        value = '<small class="muted">' + value + "</small>";
       }
       return { type, value };
     });

--- a/js/localise-times.js
+++ b/js/localise-times.js
@@ -7,6 +7,7 @@ function localise_times(site_timezone) {
     hour12: true,
     minute: 'numeric',
     dayPeriod: 'short',
+    timeZoneName: 'short',
   };
   const date_formatter_with_minutes = Intl.DateTimeFormat(undefined, options);
   delete options.minute;
@@ -28,7 +29,12 @@ function localise_times(site_timezone) {
         ? date_formatter_with_minutes
         : date_formatter_without_minutes;
 
-    let parts = formatter.formatToParts(date);
+    let parts = formatter.formatToParts(date).map(({ type, value }) => {
+      if (type == 'timeZoneName') {
+        value = '<small style="opacity: 70%;">' + value + "</small>";
+      }
+      return { type, value };
+    });
 
     if (navigator.language.startsWith('en-')) {
       // For english speaking visitors where the local format is broadly the
@@ -46,6 +52,6 @@ function localise_times(site_timezone) {
       });
     }
 
-    elem.textContent = parts.map(({ value }) => value).join("");
+    elem.innerHTML = parts.map(({ value }) => value).join("");
   });
 }

--- a/js/localise-times.js
+++ b/js/localise-times.js
@@ -17,7 +17,7 @@ function localise_times(site_timezone) {
   }
 
   document.querySelectorAll("time.time-span").forEach((elem) => {
-    const datetime = elem.parentElement.attributes.datetime.value;
+    const datetime = elem.attributes.datetime.value;
     if (!datetime) {
       return;
     }

--- a/js/localise-times.js
+++ b/js/localise-times.js
@@ -1,0 +1,51 @@
+function localise_times(site_timezone) {
+  let options = {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: 'numeric',
+    hour12: true,
+    minute: 'numeric',
+    dayPeriod: 'short',
+  };
+  const date_formatter_with_minutes = Intl.DateTimeFormat(undefined, options);
+  delete options.minute;
+  const date_formatter_without_minutes = Intl.DateTimeFormat(undefined, options);
+
+  if (date_formatter_with_minutes.resolvedOptions().timeZone == site_timezone) {
+    return;
+  }
+
+  document.querySelectorAll("time.time-span").forEach((elem) => {
+    const datetime = elem.parentElement.attributes.datetime.value;
+    if (!datetime) {
+      return;
+    }
+
+    const date = new Date(datetime);
+    const formatter =
+      date.getMinutes() > 0
+        ? date_formatter_with_minutes
+        : date_formatter_without_minutes;
+
+    let parts = formatter.formatToParts(date);
+
+    if (navigator.language.startsWith('en-')) {
+      // For english speaking visitors where the local format is broadly the
+      // same as what our event pages show, attempt to make it exactly the same.
+      parts = parts.map(({ type, value }, index) => {
+        if (type == 'literal') {
+          if (parts[index + 1].type == 'hour' && value == ", ") {
+            value = " at ";
+          }
+          if (parts[index + 1].type == 'dayPeriod' && value == " ") {
+            value = "";
+          }
+        }
+        return { type, value };
+      });
+    }
+
+    elem.textContent = parts.map(({ value }) => value).join("");
+  });
+}


### PR DESCRIPTION
This adds localisation of event times as shown on the website.

Broadly this:
- adds timezones to our source data
- extracts common date display handling
- adds `<time>` elements for machine-readability
- adds some JS to display times in the local timezone
- includes the timezone in the calendar output
