### PR TITLE
Exclude events without a datetime set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
       - run: docker info
       - run: rake build
 
+      - run: rake validate
+
   build_and_release:
     docker: *docker-template
 
@@ -29,6 +31,8 @@ jobs:
           command: gem install 'bundler:~>1' rake
       - run: docker info
       - run: rake build
+
+      - run: rake validate
 
       - run:
           name: Push Docker image

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,8 @@ gem 'jekyll-paginate'
 gem 'tzinfo',           :platforms => [:mswin, :mingw, :x64_mingw]
 gem 'tzinfo-data',      :platforms => [:mswin, :mingw, :x64_mingw]
 
+# For testing our rendered iCalendar file
+gem 'icalendar'
+
 # Avoid polling on windows
 gem 'wdm', '>= 0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,9 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    icalendar (2.7.0)
+      ice_cube (~> 0.16)
+    ice_cube (0.16.3)
     jekyll (3.8.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -77,6 +80,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  icalendar
   jekyll
   jekyll-feed
   jekyll-paginate

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ task :build_site => [:dependencies, :submodules] do
 end
 
 task :validate => [:build_site] do
-  sh('bundle exec scripts/validate-icalendar.rb')
+  sh('bundle exec ruby scripts/validate-icalendar.rb')
 end
 
 task :build_docker do

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,10 @@ task :build_site => [:dependencies, :submodules] do
   sh('bundle exec jekyll build --config _config.yml')
 end
 
+task :validate => [:build_site] do
+  sh('bundle exec scripts/validate-icalendar.rb')
+end
+
 task :build_docker do
   sh('docker build --tag srobo/website .')
 end

--- a/events.ics
+++ b/events.ics
@@ -4,7 +4,7 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:https://studentrobotics.org/
 METHOD:PUBLISH
-{% assign sorted = site.events | sort: 'date' %}
+{% assign sorted = site.events | sort: 'date' | where_exp:"item", "item.date" %}
 {% for event in sorted %}BEGIN:VEVENT
 UID:{{ event.url | prepend: site.baseurl | prepend: site.url }}
 DTSTART:{{ event.date | date: "%Y%m%dT%H%M%S" }}

--- a/scripts/validate-icalendar.rb
+++ b/scripts/validate-icalendar.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'icalendar'
+
+cal_file = File.open("_site/events.ics")
+
+cals = Icalendar::Calendar.parse(cal_file)
+for cal in cals
+  for event in cal.events
+    puts "summary: #{event.summary}"
+    puts "start date-time: #{event.dtstart}"
+    puts ""
+  end
+end


### PR DESCRIPTION
This is necessary to ensure that our calendar file is valid.