### PR TITLE
Add SRAWN web archive to reverse proxy

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -137,6 +137,11 @@ http {
       proxy_pass       https://srobo.github.io/kitbook/;
       proxy_set_header Host srobo.github.io;
     }
+    
+    location /srawn/ {
+      proxy_pass       https://srobo.github.io/srawn/;
+      proxy_set_header Host srobo.github.io;
+    }
 
     # GitHub has replaced various development related services which used to be
     # on saffron.


### PR DESCRIPTION
The updated SR(A)WN repo publishes a web archive of newsletters to GitHub pages. It is not currently finished, but I thought I should get this PR in early so that it can be deploy by 20th December.

<details>
<summary>Spoiler</summary>
Not happy about these default branch names that GitHub makes.
</details>