### PR TITLE
Enable srcomp proxying

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -132,12 +132,12 @@ http {
       proxy_pass       https://srobo.github.io/runbook/;
       proxy_set_header Host srobo.github.io;
     }
-    
+
     location /kitbook/ {
       proxy_pass       https://srobo.github.io/kitbook/;
       proxy_set_header Host srobo.github.io;
     }
-    
+
     location /srawn/ {
       proxy_pass       https://srobo.github.io/srawn/;
       proxy_set_header Host srobo.github.io;

--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -72,9 +72,9 @@ http {
       proxy_pass https://patience.studentrobotics.org/robogit-ro/;
     }
 
-    # location /comp-api/ {
-    #   proxy_pass https://srcomp.studentrobotics.org/comp-api/;
-    # }
+    location /comp-api/ {
+      proxy_pass https://srcomp.studentrobotics.org/comp-api/;
+    }
 
     # During the competition we un-comment this block to override the homepage
     # with the comeptition-specific one


### PR DESCRIPTION
Have tested this locally by building the docker image.

This is redundant if we ship #250 first.