### PR TITLE
Update to a more recent Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_only:
     docker: &docker-template
-    - image: circleci/ruby:2.5
+    - image: circleci/ruby:2.7
 
     steps:
       - checkout


### PR DESCRIPTION
This reflects the likely version users have to hand.

Hopefully this also increase the chances the image is already cached on the CI host.