### PR TITLE
Update simulator link

### DIFF
--- a/_posts/2020-07-25-post-competition.md
+++ b/_posts/2020-07-25-post-competition.md
@@ -145,7 +145,7 @@ If you would like to find out more, please [get in touch][contactus].
 
 _The SR Team_
 
-[simulator]: https://studentrobotics.org/docs/competition-simulator/
+[simulator]: https://studentrobotics.org/docs/simulator
 [rulebook]: https://studentrobotics.org/docs/resources/2020/rulebook.pdf
 [volunteers]: {{ '/volunteer' | prepend: site.baseurl }}
 [contactus]: {{ '/contact' | prepend: site.baseurl }}


### PR DESCRIPTION
While we left a redirect in place it seems that that only works for the path without a trailing slash. This change updates the url to the new one and removes the trailing slash so that it should continue to work even if the url changes again.