### PR TITLE
Fix games/rules/rulebook related broken links

### DIFF
--- a/_posts/2011-04-22-sr2011-comp-happened.md
+++ b/_posts/2011-04-22-sr2011-comp-happened.md
@@ -43,7 +43,7 @@ White presenting prizes the arena, CC-BY Rob Spanton" class="right" />
 | First Robot Movement  | Queen Elizabeth's Hospital School, Bristol
 | Online Presence       | Churcher's College, Petersfield ["Powered By Magic"](http://www.poweredbymagic.co.uk/)
 
-For full details on the awards, please see the [rulebook](/resources/2011/rulebook.pdf).
+For full details on the awards, please see the [rulebook](https://studentrobotics.org/docs/resources/2011/rulebook.pdf).
 
 Full results for all the matches are now [available](/resources/2011/all.results),
  as is the listing of the [best scores](/resources/2011/best.results) of the day.

--- a/_posts/2012-04-26-sr2012-comp-happened.md
+++ b/_posts/2012-04-26-sr2012-comp-happened.md
@@ -52,7 +52,7 @@ Results
 | Online Presence       | "[MFG Robotics](http://mfgrobotics.org/)" - Mirfield Free Grammar, Huddersfield
 | First Robot Movement  | "MFG Robotics" - Mirfield Free Grammar, Huddersfield
 
-For full details on the awards, please see the [rulebook](/resources/2012/rulebook.pdf).
+For full details on the awards, please see the [rulebook](https://studentrobotics.org/docs/resources/2012/rulebook.pdf).
 
 Media
 -----

--- a/_posts/2013-03-16-sr2013-comp-prep.md
+++ b/_posts/2013-03-16-sr2013-comp-prep.md
@@ -10,8 +10,8 @@ the University of Southampton for the largest Student Robotics Competition to
 date.
 
 In November 2012, a lecture theatre packed with sixth formers started designing
-robots to take part in ["A Strange
-Game"](/schools/game).  In this game, Robots must move
+robots to take part in ["A Strange Game"][sr2013-game-archive].
+In this game, Robots must move
 large cubes onto pedestals to form lines of tokens in a big game of
 noughts-and-crosses, while stopping their rivals from scoring too. And
 to make it more interesting, their robots must operate completely
@@ -34,3 +34,5 @@ attend too, with persons under the age of 18 accompanied by an adult.
 We look forward to seeing you there, and may the best robot win!
 
 _The SR Team_
+
+[sr2013-game-archive]: https://studentrobotics.org/docs/rules/archive#2013

--- a/_posts/2013-04-16-jaws-meet-floors.md
+++ b/_posts/2013-04-16-jaws-meet-floors.md
@@ -67,7 +67,7 @@ Results
 | First Robot Movement  | Headington School, Oxford (HSO1 & HSO2)
 | Online Presence       | [Grey Matter Robotics](http://greymatterrobotics.com/) (GMR)
 
-For full details on the awards, please see the [rulebook](/resources/2013/rulebook.pdf).
+For full details on the awards, please see the [rulebook](https://studentrobotics.org/docs/resources/2013/rulebook.pdf).
 
 Media
 -----

--- a/_posts/2014-05-03-headington-school-oxford-win-student-robotics-2014.md
+++ b/_posts/2014-05-03-headington-school-oxford-win-student-robotics-2014.md
@@ -34,7 +34,7 @@ them into tight-fitting slots. In addition, and in a first for Student Robotics,
 means to score points. The best robots had to be able to rotate them before placing the token into their designated 
 area.
 
-Find out more about the intricacies of the game in the [rulebook](/resources/2014/rulebook.pdf).
+Find out more about the intricacies of the game in the [rulebook](https://studentrobotics.org/docs/resources/2014/rulebook.pdf).
 
 Prizes
 ------
@@ -75,7 +75,7 @@ Systemetric (HRS) impressed the judges with their steampunk costumes and brass a
 
 <sup id="tie-footnote"><sup>†</sup> Due to an error in the handling of the scores in the final match, this was unfortunately announced incorrectly as only CLF on the day.</sup>
 
-For full details on the awards, please see the [rulebook](/resources/2014/rulebook.pdf).
+For full details on the awards, please see the [rulebook](https://studentrobotics.org/docs/resources/2014/rulebook.pdf).
 
 
 The Teams

--- a/_posts/2014-10-26-student-robotics-2015-starts-with-a-range-of-new-kit.md
+++ b/_posts/2014-10-26-student-robotics-2015-starts-with-a-range-of-new-kit.md
@@ -21,7 +21,10 @@ The game: Capture the Flag
 This year's competition is all about retrieving flags from around the arena and putting them into the competitor's zone 
 to get points. The flags are built from wooden cubes on ball casters.
 
-Read more about the [new game](/schools/game) or for full details please reference the [rulebook](/resources/2015/rulebook.pdf).
+Read more about the [new game][sr2015-game-archive] or for full details please reference the [rulebook][sr2015-rules-archive].
+
+[sr2015-game-archive]: https://studentrobotics.org/docs/rules/archive#2015
+[sr2015-rules-archive]: https://studentrobotics.org/docs/resources/2015/rulebook.pdf
 
 Kit upgrades
 ------------

--- a/_posts/2015-04-28-bws-victorious-sr2015.md
+++ b/_posts/2015-04-28-bws-victorious-sr2015.md
@@ -148,7 +148,7 @@ _The Student Robotics Team_
 [volunteer]: {{ '/volunteer' | prepend: site.baseurl }}
 [compete]: {{ '/compete' | prepend: site.baseurl }}
 
-[rulebook]: /resources/2015/rulebook.pdf
+[rulebook]: https://studentrobotics.org/docs/resources/2015/rulebook.pdf
 [teams-map]: https://mapsengine.google.com/map/viewer?mid=zvzw_6CVihJs.kM7Ln0NcH6zk
 [BTE]: http://www.bteacademy.co.uk/
 [BWS]: http://www.bws-school.org.uk/

--- a/_posts/2016-05-22-rgs-victorious-sr2016.md
+++ b/_posts/2016-05-22-rgs-victorious-sr2016.md
@@ -158,7 +158,7 @@ If you would like to find out more, please [get in touch][contactus].
 [compete]: {{ '/compete' | prepend: site.baseurl }}
 [volunteers]: {{ '/volunteer' | prepend: site.baseurl }}
 [contactus]: {{ '/contact' | prepend: site.baseurl }}
-[rulebook]: {{ '/resources/2016/rulebook.pdf' | prepend: site.baseurl }}
+[rulebook]: https://studentrobotics.org/docs/resources/2016/rulebook.pdf
 [teams-map]: https://www.google.com/maps/d/u/0/viewer?mid=1QsF7CVZB7NSDKZOnvsbrAF5PuJg
 [GRD2]: http://www.gordanoschool.org.uk/
 [HRS]: http://www.hillsroad.ac.uk/

--- a/_posts/2019-04-09-sr2019-tlc-crowned-champion.md
+++ b/_posts/2019-04-09-sr2019-tlc-crowned-champion.md
@@ -79,7 +79,7 @@ We love to see teams dressing up to compliment their robot theme, and this year 
 
 Lastly, we like to see the robot-building process over the course of the year, and Collyer's were keeping us up-to-date on [Twitter](https://twitter.com/CollyersRobots) all the way from Kickstart.
 
-For full details on all the awards, please see the [rulebook](/docs/resources/2019/rulebook.pdf).
+For full details on all the awards, please see the [rulebook](https://studentrobotics.org/docs/docs/resources/2019/rulebook.pdf).
 
 You can see a breakdown of scores for each match, as well as the overall league ranking on the [competition website](/comp/).
 

--- a/_posts/2019-04-09-sr2019-tlc-crowned-champion.md
+++ b/_posts/2019-04-09-sr2019-tlc-crowned-champion.md
@@ -79,7 +79,7 @@ We love to see teams dressing up to compliment their robot theme, and this year 
 
 Lastly, we like to see the robot-building process over the course of the year, and Collyer's were keeping us up-to-date on [Twitter](https://twitter.com/CollyersRobots) all the way from Kickstart.
 
-For full details on all the awards, please see the [rulebook](https://studentrobotics.org/docs/docs/resources/2019/rulebook.pdf).
+For full details on all the awards, please see the [rulebook](https://studentrobotics.org/docs/resources/2019/rulebook.pdf).
 
 You can see a breakdown of scores for each match, as well as the overall league ranking on the [competition website](/comp/).
 

--- a/_posts/2020-07-19-stage-set-for-knockouts.md
+++ b/_posts/2020-07-19-stage-set-for-knockouts.md
@@ -28,7 +28,7 @@ for a number of other awards, including the Committee Award (given to the team
 that displays the most extraordinary ingenuity in their robot), and the Online
 Presence Award (for the team that is judged to have the best online presence).
 Full details of these awards and those for earlier stages of the competition are
-available in our [rulebook](https://studentrobotics.org/docs/docs/resources/2020/rulebook.pdf)
+available in our [rulebook](https://studentrobotics.org/docs/resources/2020/rulebook.pdf)
 
 If you would like to catch up on any of the league matches from the last two
 weekends, they're available on YouTube:

--- a/_posts/2020-07-19-stage-set-for-knockouts.md
+++ b/_posts/2020-07-19-stage-set-for-knockouts.md
@@ -28,7 +28,7 @@ for a number of other awards, including the Committee Award (given to the team
 that displays the most extraordinary ingenuity in their robot), and the Online
 Presence Award (for the team that is judged to have the best online presence).
 Full details of these awards and those for earlier stages of the competition are
-available in our [rulebook](/docs/resources/2020/rulebook.pdf)
+available in our [rulebook](https://studentrobotics.org/docs/docs/resources/2020/rulebook.pdf)
 
 If you would like to catch up on any of the league matches from the last two
 weekends, they're available on YouTube:


### PR DESCRIPTION
Since https://github.com/srobo/docs/pull/107 these now have a permanent home in the docs game archive.

There are certainly other broken links around the site, however these are among the easiest to fix.

This kinda replaces https://github.com/srobo/website/pull/48, however that does touch some other links. Since that PR hasn't moved in several years I think approaching each link type separately is probably the way to go here.