### PR TITLE
Replace previous analytics with Plausible

### DIFF
--- a/_includes/script.html
+++ b/_includes/script.html
@@ -2,34 +2,5 @@
 <script src="{{ '/js/localise-times.js' | prepend: site.baseurl }}"></script>
 
 {% if site.user_tracking %}
-<!-- Piwik -->
-{% comment %}
-Note: pkBaseURL deliberately has no domain to avoid SSL reconnection since we
-serve the site at both studentrobotics.org and www.studentrobotics.org.
-{% endcomment %}
-<script type="text/javascript">
-  var pkBaseURL = "/piwik/";
-  document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-  try {
-  var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", 1);
-  piwikTracker.trackPageView();
-  piwikTracker.enableLinkTracking();
-  } catch( err ) {}
-</script>
-<!-- End Piwik Tag -->
-
-<!-- Google Analytics -->
-<script type="text/javascript">
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-84534601-1', 'auto');
-  ga('send', 'pageview');
-</script>
-<!-- End Google Analytics -->
-
+  <script defer data-domain="studentrobotics.org" src="https://plausible.io/js/plausible.js"></script>
 {% endif %}


### PR DESCRIPTION
Closes #288 

This replaces the existing analytics (Piwik, Google) with [Plausible](https://plausible.io). Plausible will also be sponsoring our access to the platform, which is great :partying_face: Adding them as a sponsor will be a later PR.

So far it's just me and the marketing team with access to the account (this will grow), however the analytics themselves are fully public at https://plausible.io/studentrobotics.org ("open by default").

See installation instructions at https://plausible.io/docs/plausible-script