### PR TITLE
Validate the nginx config on CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ end
 
 task :validate => [:build_site] do
   sh('bundle exec ruby scripts/validate-icalendar.rb')
+  sh('docker run srobo/website nginx -t')
 end
 
 task :build_docker do


### PR DESCRIPTION
We should validate that the nginx config is valid during CI. It's much easier to debug here than when it comes to deploying it to production!

See also https://github.com/srobo/reverse-proxy/issues/16