### PR TITLE
Improve links and avoid plain-http redirects

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,8 +4,8 @@
       <h4>For Competitors</h4>
       <ul class="sitemap">
         <li><a href="{{ '/teams/' | prepend: site.baseurl }}">Teams Dashboard</a></li>
-        <li><a href="/ide/">IDE</a></li>
-        <li><a href="/docs/">Documentation</a></li>
+        <li><a href="https://studentrobotics.org/ide/">IDE</a></li>
+        <li><a href="https://studentrobotics.org/docs/">Documentation</a></li>
       </ul>
     </div>
     <div class="column d-4-12 m-2-12">

--- a/_posts/2010-09-18-kickstart_happened.md
+++ b/_posts/2010-09-18-kickstart_happened.md
@@ -8,7 +8,7 @@ title: KickStart Happened. It Was Awesome!
 The annual Student Robotics competition KickStart happened today, and we think everyone had a great day!
 Everyone was certainly kept very busy!
 
-The [rulebook](/docs/rules/) is now live.
+The [rulebook](https://studentrobotics.org/docs/rules/) is now live.
 Make sure you give it a good read if you're taking part.
 For those of you that have taken part before, please note that some of the regulations have changed &mdash; don't let 
 them catch you out!

--- a/_posts/2011-10-19-sr2012-flying-start.md
+++ b/_posts/2011-10-19-sr2012-flying-start.md
@@ -8,9 +8,9 @@ working to create autonomous robots to compete in this year's game: **Pirate Plu
 *Pirate Plunder* has considerably more scope for interesting robot activity than our previous games.  Autonomous robots 
 will be racing to collect cube-shaped tokens, and get them back to the bucket in their home zone.  Robots can also steal
  each other's buckets, leading to an variety of possible tactics.  The full rules of the game can be found in our 
- [documentation pages](/docs/rules).
+ [documentation pages](https://studentrobotics.org/docs/rules).
 
-We've revamped our [API](/docs/programming) to be more powerful and work together with existing libraries more easily.  
+We've revamped our [API](https://studentrobotics.org/docs/programming) to be more powerful and work together with existing libraries more easily.
 Our new libkoki-based vision system allows our competitor's robots to easily determine where they are in the arena.
 
 We'll be here throughout the year providing teams with support both in person and through the [forums](/forum).

--- a/_posts/2012-11-05-sr2013-underway.md
+++ b/_posts/2012-11-05-sr2013-underway.md
@@ -3,7 +3,7 @@ description: Kickstart has happened and the competition is underway
 title: SR2013 is now underway
 ---
 The [KickStart](/events/kickstart) event for this year has happened,
-the [rules](/docs/rules/) have been declared
+the [rules](https://studentrobotics.org/docs/rules/) have been declared
 and the competition is underway. A number of teams have already started
 building their robots and the competition this year is sure to be fierce.
 With a whole host of new teams, as well as veterans that have been competing

--- a/_posts/2013-11-22-sr2014-underway.md
+++ b/_posts/2013-11-22-sr2014-underway.md
@@ -21,9 +21,9 @@ and exercised their robot
 building skills through a series of tasks demonstrating the range of
 functions that our electronics kit provides.
 
-This year our kit has new [motor controllers](/blog/2013-10-02-sr2014_mcv4), allowing our teams to use twice as many 
-motors as in previous years. We've also included a [ruggeduino](/docs/kit/ruggeduino) as part of each kit.  As well as 
-performing basic input and output, the ruggeduino can be reprogrammed by teams to have more advanced, custom 
+This year our kit has new [motor controllers](/blog/2013-10-02-sr2014_mcv4), allowing our teams to use twice as many
+motors as in previous years. We've also included a [ruggeduino](https://studentrobotics.org/docs/kit/ruggeduino) as part of each kit.  As well as
+performing basic input and output, the ruggeduino can be reprogrammed by teams to have more advanced, custom
 functionality.  We've also kept all of our past features, such as the servo controller and vision system.
 
 This year's game, Slots, challenges teams to collect 20cm boxes from the arena,
@@ -32,7 +32,7 @@ the adjacent slots. During the competition teams have three minutes to place as 
 against three other robots at a time.
 
 After a league and knockout stage, the best robot will be crowned the SR2014
-champion! Full details are available in the [rules](/docs/rules).
+champion! Full details are available in the [rules](https://studentrobotics.org/docs/rules).
 
 We're hoping that this years competition will produce the most innovative and
 exciting robots that we've ever seen during Student Robotics, and are looking

--- a/_posts/2014-10-26-student-robotics-2015-starts-with-a-range-of-new-kit.md
+++ b/_posts/2014-10-26-student-robotics-2015-starts-with-a-range-of-new-kit.md
@@ -35,19 +35,19 @@ These upgrades include:
 
 <img class="right" src="{{ site.baseurl }}/images/content/kit/pbv4.png" height="300" width="241" title="A new Power Board (version 4)" alt="An image of the Power Board version 4">
 
-This year comes with an all new [Power Board](/docs/kit/power_board) which allows for the control of up to six external 
+This year comes with an all new [Power Board](https://studentrobotics.org/docs/kit/power_board) which allows for the control of up to six external
 powered components.
 
 ### Brain Board
 
-The new [Brain Board](/docs/kit/brain_board) is the [Odroid U3](http://hardkernel.com/main/products/prdt_info.php).
+The new [Brain Board](https://studentrobotics.org/docs/kit/brain_board) is the [Odroid U3](http://hardkernel.com/main/products/prdt_info.php).
 It's a small but powerful Linux computer with a 1.7GHz Quad Core ARM processor and packs 2GB of RAM.
 These boards are similar to the Raspberry Pi, but are often reported as being between 6 and 12 times more powerful.
 
 
 ### Tablets
-There is an all new way of debugging robots this year, which is through the use of a [tablet](/docs/kit/tablet). The 
-tablets connect to the Brain Board through WiFi and gives the ability to view logs and start/stop the robot remotely 
+There is an all new way of debugging robots this year, which is through the use of a [tablet](https://studentrobotics.org/docs/kit/tablet). The
+tablets connect to the Brain Board through WiFi and gives the ability to view logs and start/stop the robot remotely
 &mdash; without chasing the robot half way around the school!
 
 We are also working on streaming the camera and having control over individual components.
@@ -56,7 +56,7 @@ We are also working on streaming the camera and having control over individual c
 
 <img class="right" src="{{ site.baseurl }}/images/content/kit/sbv4.png" height="281" width="241" title="A new Servo Board (version 4)" alt="An image of the Servo Board version 4">
 
-The new [Servo Board](/docs/kit/servo_board) allows for control over up to 12 servos simultaneously.
+The new [Servo Board](https://studentrobotics.org/docs/kit/servo_board) allows for control over up to 12 servos simultaneously.
 
 ### Interconnect
 

--- a/_posts/2015-02-23-sr2015-dates-announced.md
+++ b/_posts/2015-02-23-sr2015-dates-announced.md
@@ -15,4 +15,4 @@ afternoon.
 For further details please see the competition's [event page][].
 
 [venue]: http://www.newburyracecourse.co.uk/conferences-and-events/how-to-find-us/
-[rules]: /docs/rules/
+[rules]: https://studentrobotics.org/docs/rules/

--- a/_posts/2019-04-09-sr2019-tlc-crowned-champion.md
+++ b/_posts/2019-04-09-sr2019-tlc-crowned-champion.md
@@ -80,7 +80,7 @@ Lastly, we like to see the robot-building process over the course of the year, a
 
 For full details on all the awards, please see the [rulebook](https://studentrobotics.org/docs/resources/2019/rulebook.pdf).
 
-You can see a breakdown of scores for each match, as well as the overall league ranking on the [competition website](/comp/).
+You can see a breakdown of scores for each match, as well as the overall league ranking on the [competition website](https://studentrobotics.org/comp/).
 
 High resolution photographs of the event have been uploaded to our [Google Photos Album](https://photos.app.goo.gl/8vtBZiuM8FXSf79Z8).
 

--- a/_posts/2020-04-16-sr2020-virtual-competition-announcement.md
+++ b/_posts/2020-04-16-sr2020-virtual-competition-announcement.md
@@ -6,7 +6,7 @@ title: Student Robotics 2020 Virtual Competition Announcement
 
 We will be running a virtual Student Robotics Competition this summer. Our volunteers are hard at work developing a simulator-based solution for teams to compete in. 
 
-We aim to keep the virtual competition rules as similar to the SR2020 game, [Two Colours]({{ site.baseurl }}/docs/rules/), as possible.
+We aim to keep the virtual competition rules as similar to the SR2020 game, [Two Colours](https://studentrobotics.org/docs/rules/), as possible.
 
 Due to the nature of a virtual competition, we should be able to allow competing schools to enter additional teams.
 

--- a/_posts/2020-07-25-post-competition.md
+++ b/_posts/2020-07-25-post-competition.md
@@ -97,7 +97,7 @@ competition and after lockdown began as well as for their activy on the forums.
 For full details on all the awards, please see the [rulebook][rulebook].
 
 You can see a breakdown of scores for each match, as well as the overall league
-ranking on the [competition website](/comp/).
+ranking on the [competition website](https://studentrobotics.org/comp/).
 
 Rewatch the streams
 -------------------

--- a/_posts/2021-05-02-sr2021-knockouts.md
+++ b/_posts/2021-05-02-sr2021-knockouts.md
@@ -137,7 +137,7 @@ performance in the leagues.
 For full details on all the awards, please see the [rulebook][rulebook].
 
 You can see a breakdown of scores for each match, as well as the overall league
-ranking on the [competition website](/comp/).
+ranking on the [competition website](https://studentrobotics.org/comp/).
 
 Rewatch the streams
 -------------------
@@ -189,4 +189,4 @@ _The SR Team_
 [volunteers]: {{ '/volunteer' | prepend: site.baseurl }}
 [contactus]: {{ '/contact' | prepend: site.baseurl }}
 [ysh-instagram]: https://www.instagram.com/team_ysh/
-[rules]: {{ '/docs/rules' | prepend: site.baseurl }}
+[rules]: https://studentrobotics.org/docs/rules/

--- a/index.html
+++ b/index.html
@@ -170,10 +170,10 @@ layout: home
   <div class="panel-container">
     <div class="fixed-width text-center">
       <h2>Want to get involved?</h2>
-      <a class="button button-primary" href="{{ '/compete' | prepend: site.baseurl }}">Compete</a>
-      <a class="button button-primary" href="{{ '/volunteer' | prepend: site.baseurl }}">Volunteer</a>
+      <a class="button button-primary" href="{{ '/compete/' | prepend: site.baseurl }}">Compete</a>
+      <a class="button button-primary" href="{{ '/volunteer/' | prepend: site.baseurl }}">Volunteer</a>
       <a class="button button-primary" href="{{ site.links.donate }}">Donate</a>
-      <a class="button button-primary" href="{{ '/sponsor' | prepend: site.baseurl }}">Sponsor</a>
+      <a class="button button-primary" href="{{ '/sponsor/' | prepend: site.baseurl }}">Sponsor</a>
     </div>
   </div>
 </div>

--- a/sponsor.html
+++ b/sponsor.html
@@ -153,7 +153,7 @@ permalink: /sponsor/
             Each year we present 5 awards to teams based on their involvement
             throughout the year that are not based on the competition winners.
             Details of these awards can be found in the current <a
-              href="{{ '/docs/rules' | prepend: site.baseurl }}">rulebook</a>.
+              href="https://studentrobotics.org/docs/rules">rulebook</a>.
             By sponsoring one of these awards we will add your company name and
             logo onto to trophy, and announce your company name when presenting
             the award.

--- a/teams.html
+++ b/teams.html
@@ -16,7 +16,7 @@ permalink: /teams/
       <div class="row">
         <ul class="side-navigation">
           <li class="column l-4-12">
-            <a href="/ide/">
+            <a href="https://studentrobotics.org/ide/">
               <p class="link-icon"><i class="fa fa-fw fa-2x fa-cogs"></i></p>
               <p>
                 <span class="link-title">IDE</span>
@@ -25,7 +25,7 @@ permalink: /teams/
             </a>
           </li>
           <li class="column l-4-12">
-            <a href="/docs/">
+            <a href="https://studentrobotics.org/docs/">
               <p class="link-icon"><i class="fa fa-fw fa-2x fa-book"></i></p>
               <p>
                 <span class="link-title">Documentation</span>
@@ -34,7 +34,7 @@ permalink: /teams/
             </a>
           </li>
           <li class="column l-4-12">
-            <a href="/forum/">
+            <a href="https://studentrobotics.org/forum/">
               <p class="link-icon"><i class="fa fa-fw fa-2x fa-users"></i></p>
               <p>
                 <span class="link-title">Forums</span>


### PR DESCRIPTION
This changes links whose target isn't in this repo to being fully absolute, as if they were a separate website. This reflects the fact that these kinda are on separate websites and will make things easier for a link checker tool (see https://github.com/srobo/tasks/issues/701) to validate.

It also fixes some internal links where trailing slashes were missing and thus hitting plain HTTP redirects (see #290 which this helps but does not fix).