### PR TITLE
Rename "forums" to "discord" on teams dashboard

### DIFF
--- a/teams.html
+++ b/teams.html
@@ -34,10 +34,10 @@ permalink: /teams/
             </a>
           </li>
           <li class="column l-4-12">
-            <a href="https://studentrobotics.org/forum/">
+            <a href="https://studentrobotics.org/docs/team_admin/discord">
               <p class="link-icon"><i class="fa fa-fw fa-2x fa-users"></i></p>
               <p>
-                <span class="link-title">Forums</span>
+                <span class="link-title">Discord</span>
                 <span class="link-description">Stuck? Ask questions and help others.</span>
               </p>
             </a>


### PR DESCRIPTION
fixes #315 

I could also be persuaded to remove the link entirely