### PR TITLE
Normalise whitespace rather than just removing newlines

### DIFF
--- a/_includes/get_description_for_page.html
+++ b/_includes/get_description_for_page.html
@@ -1,7 +1,7 @@
 {% if page.description %}
-  {% assign description = page.description | strip_html | strip_newlines | truncate: 160 %}
+  {% assign description = page.description | strip_html | normalize_whitespace | truncate: 160 %}
 {% elsif page.excerpt %}
-  {% assign description = page.excerpt | strip_html | strip_newlines | truncate: 160 %}
+  {% assign description = page.excerpt | strip_html | normalize_whitespace | truncate: 160 %}
 {% else %}
   {% assign description = site.description %}
 {% endif %}


### PR DESCRIPTION
This correctly handles cases where paragraphs have been hard-wrapped as well as dealing with anywhere that has several pieces of whitespace next to each other (which we don't want).