### PR TITLE
Add short URL for kit feedback

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -158,6 +158,9 @@ http {
 
     # The kitbook has been incorporated back into the runbook
     rewrite ^/kitbook              /runbook/ permanent;
+    
+    # Form for kit feedback
+    rewrite ^/kit-feedback         https://forms.gle/2fh6dGajznkDGPtb9 redirect;
 
     # We have renamed the news section to blog
     rewrite ^/news/(.*) /blog/$1/ redirect;


### PR DESCRIPTION
Intentionally not marked as permanent, in case we want to change where it goes later on.