### PR TITLE
Add link to view previous events

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,8 @@ layout: home
         </div>
         <div class="column m-9-12">
           <blockquote class="text-italic">
-            Student Robotics has really helped me career wise, it’s a great talking point, especially during interviews. 
-            Being able to work on a real world engineering project with a deadline was a fantastic experience. 
+            Student Robotics has really helped me career wise, it’s a great talking point, especially during interviews.
+            Being able to work on a real world engineering project with a deadline was a fantastic experience.
             After completing my MSc in Maths, I am now doing a PhD in Maths at Sussex University.
           </blockquote>
           <p class="text-heavy text-center">— Becky</p>
@@ -283,7 +283,11 @@ layout: home
             {% endfor %}
           </ul>
           {% else %}
-          <p>There are no upcoming events.</p>
+          <p>
+            There are no upcoming events.
+            <br>
+            <a class="event-details" href="{{ '/events' | prepend: site.baseurl }}">View previous</a>
+          </p>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6527489/145286088-a45bfdbc-1060-486b-b9c4-13477cd09e80.png)

Currently, when there are no upcoming events, it's hard to see anything historical, or that we may do things in future. This restores a link we used to have back to the "all events" list page.

(Sorry for the trailing spaces cleanup, my editor did it)