### PR TITLE
Show latest blog post and next event above the fold

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,5 +17,30 @@ layout: default
     </div>
   </div>
 </div>
+<div class="panel panel-thin latest-content">
+  <div class="fixed-width">
+    <div class="content">
+      {% assign latest_post = site.posts.first %}
+      <h4>Latest Post:</h4>
+      <a href="{{ latest_post.url | prepend: site.baseurl }}">{{latest_post.title }}</a>
+      <div class="content-details">
+        {{ latest_post.date | date: "%e %B, %Y" }}
+      </div>
+    </div>
+    <div class="content">
+      {% assign next_event = site.events | where_exp: "event", "event.date > site.time"
+      | where_exp: "event", "event.cancelled != true" | first %}
+      <h4>Next Event:</h4>
+      {% if next_event %}
+        <a href="{{ next_event.url | prepend: site.baseurl }}">{{ next_event.title }}</a>
+        <div class="content-details">
+          {{ next_event.date | date: "%e %B, %Y" }}
+        </div>
+      {% else %}
+        <p>No upcoming events</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
 {{ content }}
 {% include footer.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,7 +37,9 @@ layout: default
           {{ next_event.date | date: "%e %B, %Y" }}
         </div>
       {% else %}
-        <p>No upcoming events</p>
+        No upcoming events
+        <br/>
+        <a class="content-details" href="{{ '/events' | prepend: site.baseurl }}">View previous</a>
       {% endif %}
     </div>
   </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -21,7 +21,7 @@ layout: default
   <div class="fixed-width">
     <div class="content">
       {% assign latest_post = site.posts.first %}
-      <h4>Latest Post:</h4>
+      <h4>Latest Post</h4>
       <a href="{{ latest_post.url | prepend: site.baseurl }}">{{latest_post.title }}</a>
       <div class="content-details">
         {{ latest_post.date | date: "%e %B, %Y" }}
@@ -30,7 +30,7 @@ layout: default
     <div class="content">
       {% assign next_event = site.events | where_exp: "event", "event.date > site.time"
       | where_exp: "event", "event.cancelled != true" | first %}
-      <h4>Next Event:</h4>
+      <h4>Next Event</h4>
       {% if next_event %}
         <a href="{{ next_event.url | prepend: site.baseurl }}">{{ next_event.title }}</a>
         <div class="content-details">

--- a/_sass/panel.scss
+++ b/_sass/panel.scss
@@ -90,3 +90,32 @@ img.image {
 .panel-fill {
   width: 100%;
 }
+
+.panel.latest-content {
+  padding: 1rem 0;
+
+  .fixed-width {
+    display: flex;
+    justify-content: space-around;
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
+      h4 {
+        margin-bottom: 0;
+      }
+
+      a {
+        font-weight: bold;
+      }
+
+      .content-details {
+        font-size: 0.8em;
+        margin: 0;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+}

--- a/_sass/panel.scss
+++ b/_sass/panel.scss
@@ -96,12 +96,13 @@ img.image {
 
   .fixed-width {
     display: flex;
-    justify-content: space-around;
 
     .content {
       display: flex;
       flex-direction: column;
       align-items: center;
+      text-align: center;
+      flex: 1;
 
       h4 {
         margin-bottom: 0;


### PR DESCRIPTION
At the moment these are only accessible by scrolling a long way down the page or through the Teams dashboard (which #345 removes).

With an upcoming event
![image](https://user-images.githubusercontent.com/1496834/145651166-6c71ed48-2264-41c9-943b-c46048294cc0.png)

Without an upcoming event
![image](https://user-images.githubusercontent.com/1496834/145651197-6e9c183b-b387-444a-b0e8-dbb112d168b5.png)
