### PR TITLE
Improve layout of sponsors logos on homepage

### DIFF
--- a/_sass/sponsors.scss
+++ b/_sass/sponsors.scss
@@ -102,4 +102,5 @@ ul.sponsor-list {
   display: flex;
   justify-content: center;
   flex-flow: wrap;
+  row-gap: 0.5rem;
 }

--- a/_sass/sponsors.scss
+++ b/_sass/sponsors.scss
@@ -101,4 +101,5 @@ ul.sponsor-list {
 .sponsor-row {
   display: flex;
   justify-content: center;
+  flex-flow: wrap;
 }

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@ layout: home
       <div class="column">
         <div class="row sponsor-row">
           {% for sponsor in site.sponsors %}
-          <div class="column m-6-12">
+          <div class="column m-4-12">
             <a href="{{ sponsor.link }}">
               <img src="{{ sponsor.image | prepend: site.baseurl }}" alt="{{ sponsor.name }}" />
             </a>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1496834/146466598-35f778b3-ce7d-4d85-98a6-cce290620ed7.png)
![image](https://user-images.githubusercontent.com/1496834/146466620-eced4fa3-d846-4ba9-8ffb-96920a9af87b.png)

After:
![image](https://user-images.githubusercontent.com/1496834/146466359-ea0963a4-2608-4cb3-80e0-b39c9e9af2f7.png)
![image](https://user-images.githubusercontent.com/1496834/146466538-bc66b5ab-c3ef-4cbe-b865-05859c78a1a8.png)
![image](https://user-images.githubusercontent.com/1496834/146466564-ba855448-636c-4aea-8dea-7fa9cb523719.png)
![image](https://user-images.githubusercontent.com/1496834/146466657-e1c27785-0905-4aee-91a3-6568bcbad0f6.png)

Closes #348 