### PR TITLE
Update `listen` to 3.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,9 +13,9 @@ GEM
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     eventmachine (1.2.7-x86-mingw32)
-    ffi (1.15.0)
-    ffi (1.15.0-x64-mingw32)
-    ffi (1.15.0-x86-mingw32)
+    ffi (1.15.5)
+    ffi (1.15.5-x64-mingw32)
+    ffi (1.15.5-x86-mingw32)
     forwardable-extended (2.6.0)
     html-proofer (3.19.2)
       addressable (~> 2.3)
@@ -56,7 +56,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.5.1)
+    listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
@@ -77,7 +77,7 @@ GEM
     racc (1.5.2)
     rainbow (3.0.0)
     rake (12.3.3)
-    rb-fsevent (0.10.4)
+    rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
@@ -117,4 +117,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   2.2.4
+   2.3.5


### PR DESCRIPTION
Upon trying to build the site on an ARM Mac I got this error:

```
E, [2022-01-23T11:40:08.416990 #66506] ERROR -- : Exception rescued in listen-worker_thread:
Errno::EBADARCH: Bad CPU type in executable - /Users/kjk/Projects/srobo-website/gems/ruby/2.7.0/gems/rb-fsevent-0.10.4/bin/fsevent_watch
```

As much as I could run it using an x86 copy of Ruby under Rosetta, it would be nice to be able to run it natively – updating this package solves that.