### PR TITLE
Transparently proxy the new reverse proxy

### DIFF
--- a/_env/nginx.conf
+++ b/_env/nginx.conf
@@ -24,9 +24,6 @@ http {
     image/x-icon
   ;
 
-  add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" always;
-  add_header X-Frame-Options "SAMEORIGIN" always;
-
   server {
     listen         80;
     server_name    localhost;
@@ -36,155 +33,9 @@ http {
     proxy_set_header X-Real-IP          $remote_addr;
     proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto  https;
-    proxy_set_header Host               $host;
-
-    #location /ide/ {
-    #  proxy_pass https://patience.studentrobotics.org/ide/;
-    #}
-
-    location /forum/ {
-      # proxy_pass https://patience.studentrobotics.org/forum/;
-      return 307 /docs/team_admin/discord;
-    }
-
-    #location /docs/python/ {
-    #  proxy_pass https://patience.studentrobotics.org/docs/python/;
-    #}
-
-    location /docs/ {
-      proxy_pass       https://srobo.github.io/docs/;
-      proxy_set_header Host srobo.github.io;
-    }
-
-    #location /userman/ {
-    #  proxy_pass https://patience.studentrobotics.org/userman/;
-    #}
-
-    #location /code-submitter/ {
-    #  proxy_pass https://patience.studentrobotics.org/code-submitter/;
-    #}
-
-    #location /robogit/ {
-    #  proxy_pass https://patience.studentrobotics.org/robogit/;
-    #}
-
-    #location /robogit-ro/ {
-    #  proxy_pass https://patience.studentrobotics.org/robogit-ro/;
-    #}
-
-    #location /comp-api/ {
-    #  proxy_pass https://srcomp.studentrobotics.org/comp-api/;
-    #}
-
-    # During the competition we un-comment this block to override the homepage
-    # with the comeptition-specific one
-    # location = / {
-    #   proxy_pass       https://srobo.github.io/competition-website/comp/;
-    #   proxy_set_header Host srobo.github.io;
-    #
-    #   sub_filter "/competition-website/comp/" "/comp/";
-    #   sub_filter_once off;
-    #   sub_filter_last_modified on;
-    #   # Tell GitHub that we want these pages to be sent to us uncompressed
-    #   # otherwise the sub_filter above doesn't work. We'll compress it on the
-    #   # way out anyway, so clients don't lose anything by us doing this.
-    #   proxy_set_header Accept-Encoding "";
-    # }
-    # Provide access to the competition pages under the normal prefix
-    location /comp/ {
-      proxy_pass       https://srobo.github.io/competition-website/comp/;
-      proxy_set_header Host srobo.github.io;
-
-      sub_filter "/competition-website/comp/" "/comp/";
-      sub_filter_once off;
-      sub_filter_last_modified on;
-      # Tell GitHub that we want these pages to be sent to us uncompressed
-      # otherwise the sub_filter above doesn't work. We'll compress it on the
-      # way out anyway, so clients don't lose anything by us doing this.
-      proxy_set_header Accept-Encoding "";
-    }
-    # Also provide access under the prefix which github insists on using
-    # so that the secondary resources (JS, CSS, etc.) load
-    location /competition-website/ {
-      proxy_pass       https://srobo.github.io/competition-website/;
-      proxy_set_header Host srobo.github.io;
-    }
-
-    # Disable custom media consent endpoint
-    #location /mediaconsent/ {
-    #  proxy_pass https://patience.studentrobotics.org/mediaconsent/;
-    #}
-
-    #location /tickets/ {
-    #  proxy_pass https://patience.studentrobotics.org/tickets/;
-    #}
-
-    #location /ticket-api/ {
-    #  proxy_pass https://patience.studentrobotics.org/ticket-api/;
-    #}
-
-    location /style/ {
-      proxy_pass       https://srobo.github.io/style/;
-      proxy_set_header Host srobo.github.io;
-    }
-
-    location /runbook/ {
-      proxy_pass       https://srobo.github.io/runbook/;
-      proxy_set_header Host srobo.github.io;
-    }
-
-    location /srawn/ {
-      proxy_pass       https://srobo.github.io/srawn/;
-      proxy_set_header Host srobo.github.io;
-    }
-
-    # GitHub has replaced various development related services which used to be
-    # on saffron.
-    rewrite ^/(c?git|gerrit) https://github.com/srobo/ redirect;
-
-    # Various old website redirects
-    rewrite ^/schools/how_to_enter /compete redirect;
-    rewrite ^/about/how_to_help    /volunteer redirect;
-    rewrite ^/about/contactus      /contact redirect;
-    rewrite ^/sponsors             /sponsor/ redirect;
-    rewrite ^/about/sponsors       /sponsor/ redirect;
-    rewrite ^/key_dates            /events redirect;
-    rewrite ^/feed.php             /feed.xml redirect;
-    rewrite ^/password             /userman/ permanent;
-    rewrite ^/rules                /docs/rules/ permanent;
-
-    # The runbook has replaced trac
-    rewrite ^/trac                 /runbook/ permanent;
-
-    # The kitbook has been incorporated back into the runbook
-    rewrite ^/kitbook              /runbook/ permanent;
-    
-    # Form for kit feedback
-    rewrite ^/kit-feedback         https://forms.gle/2fh6dGajznkDGPtb9 redirect;
-
-    # We have renamed the news section to blog
-    rewrite ^/news/(.*) /blog/$1/ redirect;
-    rewrite ^/assets/image/content/news/(.*) /images/content/blog/$1 redirect;
-
-    # About page has been merged into the home page
-    rewrite ^/about / redirect;
 
     location / {
-      proxy_pass       https://srobo.github.io/website/;
-      proxy_set_header Host srobo.github.io;
-      # Work around github.io redirect issue (see above)
-      proxy_redirect   http://srobo.github.io/website/ /;
-      proxy_redirect   https://srobo.github.io/website/ /;
-
-      sub_filter "/website/" "/";
-      sub_filter_once off;
-      sub_filter_types application/xml text/calendar text/css; # in addition to text/html
-      sub_filter_last_modified on;
-
-      # Tell GitHub that we want these pages to be sent to us uncompressed
-      # otherwise the sub_filter above doesn't work. We'll compress it on the
-      # way out anyway, so clients don't lose anything by us doing this.
-      proxy_set_header Accept-Encoding "";
+      proxy_pass https://beta.studentrobotics.org/;
     }
 
     error_page        404 /404.html;


### PR DESCRIPTION
This will allow us to migrate over with minimal disruption.

Once this is in place I'll reconfigure `monty` so it grabs a TLS cert that covers all the domains from Let's Encrypt.