### PR TITLE
Standardise spelling of livestream

### DIFF
--- a/_events/sr2020/virtual-competition-knockouts.md
+++ b/_events/sr2020/virtual-competition-knockouts.md
@@ -10,6 +10,6 @@ The Student Robotics Competition marks the ultimate stage of SR2020, showcasing 
 
 Code submission will be due at 10am BST: [Submit your code](https://studentrobotics.org/code-submitter/)
 
-Our live-stream will start at 3pm BST: [Watch live](https://youtu.be/xBPVqsb_Ydk)
+Our livestream will start at 3pm BST: [Watch live](https://youtu.be/xBPVqsb_Ydk)
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/xBPVqsb_Ydk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2020/virtual-competition-league-1.md
+++ b/_events/sr2020/virtual-competition-league-1.md
@@ -10,6 +10,6 @@ The Student Robotics Competition marks the ultimate stage of SR2020, showcasing 
 
 Code submission will be due at 10am BST: [Submit your code](https://studentrobotics.org/code-submitter/)
 
-Our live-stream will start at 3pm BST: [Watch live](https://youtu.be/xLL7SoQywf4)
+Our livestream will start at 3pm BST: [Watch live](https://youtu.be/xLL7SoQywf4)
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/xLL7SoQywf4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2020/virtual-competition-league-2.md
+++ b/_events/sr2020/virtual-competition-league-2.md
@@ -10,6 +10,6 @@ The Student Robotics Competition marks the ultimate stage of SR2020, showcasing 
 
 Code submission will be due at 10am BST: [Submit your code](https://studentrobotics.org/code-submitter/)
 
-Our live-stream will start at 3pm BST: [Watch live](https://youtu.be/7JoW4zXSeZE)
+Our livestream will start at 3pm BST: [Watch live](https://youtu.be/7JoW4zXSeZE)
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/7JoW4zXSeZE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2020/virtual-competition-league-3.md
+++ b/_events/sr2020/virtual-competition-league-3.md
@@ -10,6 +10,6 @@ The Student Robotics Competition marks the ultimate stage of SR2020, showcasing 
 
 Code submission will be due at 10am BST: [Submit your code](https://studentrobotics.org/code-submitter/)
 
-Our live-stream will start at 3pm BST: [Watch live](https://youtu.be/symUE1E4niI)
+Our livestream will start at 3pm BST: [Watch live](https://youtu.be/symUE1E4niI)
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/symUE1E4niI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2020/virtual-competition-league-4.md
+++ b/_events/sr2020/virtual-competition-league-4.md
@@ -10,6 +10,6 @@ The Student Robotics Competition marks the ultimate stage of SR2020, showcasing 
 
 Code submission will be due at 10am BST: [Submit your code](https://studentrobotics.org/code-submitter/)
 
-Our live-stream will start at 3pm BST: [Watch live](https://youtu.be/Y4h5P47j8jM)
+Our livestream will start at 3pm BST: [Watch live](https://youtu.be/Y4h5P47j8jM)
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/Y4h5P47j8jM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2021/kickstart.md
+++ b/_events/sr2021/kickstart.md
@@ -21,7 +21,7 @@ communicate and collaborate, both to share ideas and discuss potential questions
 
 There's still time to [sign up][sign-up] if you have't already! Deadline for entries is the 19th November 2020.
 
-Our live-stream will start at 1pm GMT: [Watch live](https://www.youtube.com/watch?v=cQOgo0Gh4iA)
+Our livestream will start at 1pm GMT: [Watch live](https://www.youtube.com/watch?v=cQOgo0Gh4iA)
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/cQOgo0Gh4iA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/_events/sr2021/league-1.md
+++ b/_events/sr2021/league-1.md
@@ -10,7 +10,7 @@ This is the first league round of this year's competition and the first time we 
 
 Code submission will be due at 8am GMT: [Submit your code](https://studentrobotics.org/code-submitter/)
 
-Our live-stream will start at noon GMT: [Watch live](https://www.youtube.com/watch?v=cAvk-nfTUis)
+Our livestream will start at noon GMT: [Watch live](https://www.youtube.com/watch?v=cAvk-nfTUis)
 
 <iframe
   width="100%"

--- a/_events/sr2022/kickstart.md
+++ b/_events/sr2022/kickstart.md
@@ -15,7 +15,7 @@ During the event, we recommend setting up a call or video chat for you and your 
 
 There's still time to [sign up][sign-up] if you haven't already!
 
-Our live-stream will start at 1pm GMT: [Watch live](https://www.youtube.com/watch?v=QdZSiUWU4Sk)
+Our livestream will start at 1pm GMT: [Watch live](https://www.youtube.com/watch?v=QdZSiUWU4Sk)
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/QdZSiUWU4Sk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/_posts/2014-05-03-headington-school-oxford-win-student-robotics-2014.md
+++ b/_posts/2014-05-03-headington-school-oxford-win-student-robotics-2014.md
@@ -22,7 +22,7 @@ Up to four robots competed head to head in each round, pushing past each other t
 3 minutes.
 Run entirely by volunteers, Student Robotics is free for teams to enter thanks to [our sponsors]({{ '/sponsor/' | prepend: site.baseurl }}),
 primarily the Motorola Foundation and the University of Southampton's School of Electronics and Computer Science. This
-year the competition was also live-streamed on the internet thanks to our latest sponsor,
+year the competition was also livestreamed on the internet thanks to our latest sponsor,
 the [British Amateur Television Club](http://www.batc.org.uk/).
 
 The challenge: *Slots*

--- a/_posts/2020-07-25-post-competition.md
+++ b/_posts/2020-07-25-post-competition.md
@@ -23,7 +23,7 @@ available this year are available in the [rulebook][rulebook].
 
 Our competition event this year was rather different to normal as COVID-19
 prevented our usual weekend event. Instead the competition took place over
-three weekends, with matches being live-streamed from within a simulator.
+three weekends, with matches being livestreamed from within a simulator.
 While this changed many aspects of the competition, the core challenge to create
 an autonomous robot remained the same.
 

--- a/volunteer.html
+++ b/volunteer.html
@@ -65,7 +65,7 @@ permalink: /volunteer/
         </div>
         <div class="column s-4-12">
           <img src="{{ '/images/advertising/volunteers/sr2019-volunteers-at-tech-desk.jpg' | prepend: site.baseurl }}"
-            alt="Three volunteers focused on their laptops which show live-streaming to YouTube" />
+            alt="Three volunteers focused on their laptops which show livestreaming to YouTube" />
           <h3 class="text-center">Development</h3>
           <p>
             Student Robotics relies heavily on an array of hardware and


### PR DESCRIPTION
We had both `live-stream` and `livestream` on different pages. Let's standardise on `livestream`

https://twitter.com/APStylebook/status/847508247917477889?s=20&t=M45YWXIulNQR0yvfd4CQlg

(Changes prompted by https://github.com/srobo/website/pull/374#discussion_r806539927)