### PR TITLE
Add a bit more space around the sponsor logos on the homepage

### DIFF
--- a/_sass/sponsors.scss
+++ b/_sass/sponsors.scss
@@ -105,7 +105,6 @@ ul.sponsor-list {
   row-gap: 0.5rem;
 
   div {
-    padding-top: 0.2em;
-    padding-bottom: 0.2em;
+    padding: 0.2em 0.7em;
   }
 }

--- a/_sass/sponsors.scss
+++ b/_sass/sponsors.scss
@@ -103,4 +103,9 @@ ul.sponsor-list {
   justify-content: center;
   flex-flow: wrap;
   row-gap: 0.5rem;
+
+  div {
+    padding-top: 0.2em;
+    padding-bottom: 0.2em;
+  }
 }


### PR DESCRIPTION
This is partly based on working with #390, but should be generally useful.