### PR TITLE
Update COVID guidance before the upcoming techday

### DIFF
--- a/covid-19.md
+++ b/covid-19.md
@@ -8,9 +8,10 @@ We will keep this page updated with new information as it becomes available.
 
 Last updated: {{ page.date | date: "%e %B %Y" }}.
 
-1. Anyone who is experiencing symptoms of COVID-19, or has tested positive for COVID-19 in the 7 days beforehand (or lives with someone who has) must not attend.
+1. If you are experiencing symptoms of COVID-19, or have tested positive for COVID-19 in the 7 days beforehand (or live with someone who has) please do not attend.
 2. If you are able, please wear a mask when not in your team pit.
 3. Please clean your hands regularly, using hand sanitizer or soap.
+4. Be respectful towards others personal space.
 
 ## The Competition - SR2022
 

--- a/covid-19.md
+++ b/covid-19.md
@@ -11,7 +11,7 @@ Last updated: {{ page.date | date: "%e %B %Y" }}.
 1. If you are experiencing symptoms of COVID-19, or have tested positive for COVID-19 in the 7 days beforehand (or live with someone who has) please do not attend.
 2. If you are able, please wear a mask when not in your team pit.
 3. Please clean your hands regularly, using hand sanitizer or soap.
-4. Be respectful towards others personal space.
+4. Be respectful towards others' personal space.
 
 ## The Competition - SR2022
 

--- a/covid-19.md
+++ b/covid-19.md
@@ -8,13 +8,19 @@ We will keep this page updated with new information as it becomes available.
 
 Last updated: {{ page.date | date: "%e %B %Y" }}.
 
-1. If you are experiencing symptoms of COVID-19, or have tested positive for COVID-19 in the 7 days beforehand (or live with someone who has) please do not attend.
-2. If you are able, please wear a mask when not in your team pit.
-3. Please clean your hands regularly, using hand sanitizer or soap.
-4. Be respectful towards others' personal space.
+## SR2022
 
-## The Competition - SR2022
+Life is beginning to get back to normal, and this means we are finally able to do in person events again!
+However, we must recognise that some people still have to be cautious, to protect their own health or their friends or family.
+As such, we ask that everyone follows the below requests to help ensure we all keep safe, whilst still having lots of fun with robots!
 
-It is currently our intention to run an in person competition for the SR2022 competition cycle. This is of course dependent on the government guidelines which we are keeping a close eye on. If you have any COVID-19 specific questions about the competition please contact us at [{{ site.emails.teams }}][teams-email].
+* If you are experiencing symptoms of COVID-19, or have tested positive for COVID-19 in the 7 days beforehand (or live with someone who has) please do not attend.
+* If you are able, please wear a mask when not in your team pit.
+* Please clean your hands regularly, using hand sanitizer or soap.
+* Be respectful towards others' personal space.
+
+We are keeping a close eye on government guidelines, and will continue to update this page as required.
+
+If you have any questions please contact us at [{{ site.emails.teams }}][teams-email].
 
 [teams-email]: mailto:{{ site.emails.teams }}

--- a/covid-19.md
+++ b/covid-19.md
@@ -1,12 +1,16 @@
 ---
 layout: blog
 title: COVID-19 Updates
-date: 2021-12-08
+date: 2022-03-31
 ---
 
 We will keep this page updated with new information as it becomes available.
 
 Last updated: {{ page.date | date: "%e %B %Y" }}.
+
+1. Anyone who is experiencing symptoms of COVID-19, or has tested positive for COVID-19 in the 7 days beforehand (or lives with someone who has) must not attend.
+2. If you are able, please wear a mask when not in your team pit.
+3. Please clean your hands regularly, using hand sanitizer or soap.
 
 ## The Competition - SR2022
 


### PR DESCRIPTION
In the absence of information from the venues, and recognising that we need something in place by the tech day this weekend, I suggest we add this COVID policy. I am expecting it to change to some degree before the competition.