### PR TITLE
Don't collapse day period specifiiers which contain spaces

### DIFF
--- a/js/localise-times.js
+++ b/js/localise-times.js
@@ -44,7 +44,7 @@ function localise_times(site_timezone) {
           if (parts[index + 1].type == 'hour' && value == ", ") {
             value = " at ";
           }
-          if (parts[index + 1].type == 'dayPeriod' && value == " ") {
+          if (parts[index + 1].type == 'dayPeriod' && value == " " && !parts[index + 1].value.includes(" ")) {
             value = "";
           }
         }


### PR DESCRIPTION
The presence of spaces in these suggests that they're not suitable for collapsing next to the time (e.g: "11 in the morning" rather than "11am").

Fixes the issue of over-collapsing visible in:
![image](https://user-images.githubusercontent.com/336212/163577002-507cec7a-6354-49d6-b7be-044eb0f4cc14.png)