### PR TITLE
Prevent any time elements from wrapping

### DIFF
--- a/_sass/common.scss
+++ b/_sass/common.scss
@@ -63,3 +63,7 @@
   display: flex;
   justify-content: center;
 }
+
+time {
+  white-space: nowrap;
+}

--- a/_sass/events.scss
+++ b/_sass/events.scss
@@ -73,7 +73,3 @@ ul.event-listing {
 .muted {
   opacity: 70%;
 }
-
-.event-date time {
-  white-space: nowrap;
-}


### PR DESCRIPTION
We can't just target the ones on the event page, as they also exist on the event listing page.

In reality, we probably don't want them ever to wrap.