### PR TITLE
Ensure variables are cleared if they're not needed

### DIFF
--- a/_includes/datetime.html
+++ b/_includes/datetime.html
@@ -1,5 +1,7 @@
 {% if include.event.cancelled %}
   {% assign cancelled = 'style="text-decoration: line-through;"' %}
+{% else %}
+  {% assign cancelled = '' %}
 {% endif %}
 {% if include.event.time_tbc %}
   <time
@@ -36,6 +38,7 @@
       {% assign time_only = 'data-time-only' %}
     {% else %}
       {% assign end_date_format = include.datetime_format %}
+      {% assign time_only = '' %}
     {% endif %}
 
     &mdash;


### PR DESCRIPTION
Turns out these assignments are not scoped to the template they are defined in, and get reused with future calls when rendering the same page

The effect of this issue can be seen on the events page, where it shows non-cancelled events with the cancelled styling

![image](https://user-images.githubusercontent.com/6527489/163585974-917624c7-e0e5-4eaa-8a20-31bccef90512.png)
