### PR TITLE
Add a Sunday afternoon league match session

### DIFF
--- a/_events/sr2022/competition.md
+++ b/_events/sr2022/competition.md
@@ -34,7 +34,8 @@ Time | Activity
 11:00 | League Matches
 12:30 | Lunch and Tinker Time
 13:30 | Competition Photo
-14:00 | Knockouts ([matches][knockouts-schedule])
+14:00 | League Matches
+14:45 | Knockouts ([matches][knockouts-schedule])
 16:20 | Prize Ceremony
 16:45 | Kit Return
 17:00 | End of Day


### PR DESCRIPTION
Turns out that we'd allowed a lot more time for the knockouts than was needed. This pushes them later and makes room for the league matches we're adding to make use of the time.

See also https://github.com/srobo/sr2022-comp/pull/10