### PR TITLE
Remove clash with platinum sponsor tier

### DIFF
--- a/sponsor.html
+++ b/sponsor.html
@@ -86,7 +86,7 @@ permalink: /sponsor/
             <li>All the perks of Silver sponsorship</li>
             <li>Logo on the volunteer t-shirts</li>
             <li>Friendly mention and thank you at the competition</li>
-            <li>Sponsor an award - put your name to one of our existing awards, or suggest a new award and define the judging criteria</li>
+            <li>Sponsor an award - put your name to one of our awards</li>
           </ul>
         </div>
         <div class="column s-6-12 sponsor-level-image">


### PR DESCRIPTION
Closes #363 
These two were a bit similar
Gold: Sponsor an award - put your name to one of our existing awards, or suggest a new award and define the judging criteria
Platinum: Set a challenge for teams, and declare the winner at the competition

Have removed the extra bit from the gold tier