### PR TITLE
Rename sponsor-logo class to avoid adblock

### DIFF
--- a/_sass/sponsors.scss
+++ b/_sass/sponsors.scss
@@ -109,7 +109,8 @@ ul.sponsor-list {
   }
 }
 
-.sponsor-logo {
+// not just 'sponsor-logo' to avoid ad blockers hiding them.
+.charity-sponsor-logo {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@ layout: home
       <div class="column">
         <div class="row sponsor-row">
           {% for sponsor in site.sponsors %}
-          <div class="column m-4-12 sponsor-logo">
+          <div class="column m-4-12 charity-sponsor-logo">
             <a href="{{ sponsor.link }}">
               <img src="{{ sponsor.image | prepend: site.baseurl }}" alt="{{ sponsor.name }}" style="width: {{ sponsor.logo_width }}" />
             </a>

--- a/sponsor.html
+++ b/sponsor.html
@@ -133,7 +133,7 @@ permalink: /sponsor/
       <div class="column">
         <div class="row sponsor-row">
           {% for sponsor in site.sponsors %}
-          <div class="column m-4-12 sponsor-logo">
+          <div class="column m-4-12 charity-sponsor-logo">
             <a href="{{ sponsor.link }}">
               <img src="{{ sponsor.image | prepend: site.baseurl }}" alt="{{ sponsor.name }}" style="width: {{ sponsor.logo_width }}" />
             </a>


### PR DESCRIPTION
It feels reasonable that we do this as these aren't advertisers -- they are genuinely sponsors of us as a charity, so aren't the kind of thing that adblock extensions would normally aim to hide.

Additionally these content are served entirely from our own hosting, so there's no user-tracking implications from these being shown.

If we're happy with this approach I'll copy it over to https://github.com/srobo/competition-website/ too