### PR TITLE
Add registrations blog post for SR2023

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -41,6 +41,7 @@ ruggeduino
 Runshaw
 Scarsbrook
 Scarzy
+signup
 Spanton
 srobo
 studentrobotics

--- a/_events/sr2023/kickstart.md
+++ b/_events/sr2023/kickstart.md
@@ -1,0 +1,19 @@
+---
+title: Kickstart
+layout: event
+type: kickstart
+location: Various
+---
+
+Kickstart is the event which kicks off a competition year. The structure of the
+competition, the game rules will be announced, kits will be handed out and of
+course any questions you have will be answered.
+
+Kickstart will be in person at a number of venues near teams. The date is
+expected to be on a Saturday at the end of October and will be announced closer
+to the time.
+
+There's still time to [sign up][sign-up] if you have't already!
+Deadline for entries is Friday 30th September 2022.
+
+[sign-up]: {{ site.baseurl }}/compete/

--- a/_posts/2022-09-08-sr2023-registration-open.md
+++ b/_posts/2022-09-08-sr2023-registration-open.md
@@ -23,8 +23,7 @@ We expect to confirm places at the end of September.
 
 If you would like a chance to [compete][compete] in Student Robotics 2023,
 please fill in the [entry form][entry-form] with the required information.
-We're expecting to run with a similar number of teams to SR2019, so places
-will go fast.
+Places are limited, so sign up soon to avoid disappointment.
 
 We look forward to seeing your teams!
 

--- a/_posts/2022-09-08-sr2023-registration-open.md
+++ b/_posts/2022-09-08-sr2023-registration-open.md
@@ -1,0 +1,33 @@
+---
+title: Registration opens for Student Robotics 2023
+---
+
+We're excited to announce that registration for the 2023 season of Student
+Robotics is now open!
+
+The competition cycle will start with in-person [kickstart events][kickstart] at
+locations near teams. During the event the game and the structure of the
+competition will be announced and kits handed out to teams.
+
+While the details for kickstart are not yet available, the events are expected
+to take place on the same weekend in late October.
+
+The competition year will culminate in an in-person competition over two days in
+early April 2023, which will see the robots compete through a league stage and a
+seeded knockout. As usual the prizes will recognise not only the teams which
+come top in the knockouts, but also those who excel in other ways.
+
+Details of the game and prizes will be revealed at kickstart. Details of the
+kickstart and competition events will be published when they are available.
+We expect to confirm places at the end of September.
+
+If you would like a chance to [compete][compete] in Student Robotics 2023,
+please fill in the [entry form][entry-form] with the required information.
+We're expecting to run with a similar number of teams to SR2019, so places
+will go fast.
+
+We look forward to seeing your teams!
+
+[kickstart]: {{ '/events/sr2023/kickstart' | prepend: site.baseurl }}
+[compete]: {{ '/compete' | prepend: site.baseurl }}
+[entry-form]: {{ '/compete#signup' | prepend: site.baseurl }}


### PR DESCRIPTION
Depends on https://github.com/srobo/website/pull/428 for getting the actually right signup form onto the compete page.