### PR TITLE
Close signups for SR2023

### DIFF
--- a/compete.html
+++ b/compete.html
@@ -140,7 +140,7 @@ permalink: /compete/
       <a name="signup"></a><h2>Want to compete?</h2>
       <div class="column m-8-12 m-offset-2-12 text-left">
         <p>
-          Registration for the Student Robotics 2023 competition have now closed.
+          Registration for the Student Robotics 2023 competition has now closed.
         </p>
         <p>
           If you would like to register your interest in applying for a place in

--- a/compete.html
+++ b/compete.html
@@ -140,12 +140,17 @@ permalink: /compete/
       <a name="signup"></a><h2>Want to compete?</h2>
       <div class="column m-8-12 m-offset-2-12 text-left">
         <p>
-          Please register your interest below, we'll let you know when your place is confirmed.
+          Registration for the Student Robotics 2023 competition have now closed.
+        </p>
+        <p>
+          If you would like to register your interest in applying for a place in
+          a future competition, please enter your details below and we'll
+          contact you once applications for next year's competition have opened.
         </p>
         <p class="text-heavy">
           You must be over 18 to run a Student Robotics team and so you must also be over 18 to fill in this form.
         </p>
-        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSevt8r3OBgMWaIVF2gr5UYsEld0Y_2zu9QC8K2O92aCFU_I4A/viewform?embedded=true" width="100%" height="3052" frameborder="0">Loading&hellip;</iframe>
+        {% include team-signup.html %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This removes the signup form and swaps back to the default MailChimp contact details form.