### PR TITLE
Ingore node_modules when building the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,6 +120,7 @@ exclude:
   - Gemfile.lock
   - circle.yml
   - gems/
+  - node_modules/
   - scripts/
   - .idea/
   - .vscode/


### PR DESCRIPTION
This won't be present when GitHub Pages builds the site, so having it present is merely likely to create confusion (as well as slow down the build locally/in CI).