### PR TITLE
Fix sponsor level image expanding behind the level description

### DIFF
--- a/_sass/sponsors.scss
+++ b/_sass/sponsors.scss
@@ -36,7 +36,6 @@ ul.sponsor-list {
   }
 }
 .sponsor-level-image {
-  height: 300px;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
<details>
<summary>
Before (Mobile)
</summary>

![image](https://user-images.githubusercontent.com/1496834/195911796-37ba8722-ffce-4d31-9f1d-7725cad056da.png)
</details>

<details>
<summary>
After (Mobile)
</summary>

![image](https://user-images.githubusercontent.com/1496834/195911940-f6503fd7-ccd1-4c3c-9b4d-605c36184852.png)
</details>

<details>
<summary>
Before (Desktop)
</summary>

![image](https://user-images.githubusercontent.com/1496834/195912056-2351e249-a49c-4615-ad6b-3c53af7a8632.png)
</details>

<details>
<summary>
After (Desktop)
</summary>

![image](https://user-images.githubusercontent.com/1496834/195912178-346d30f4-36a3-4e88-910d-8016d7cee93e.png)
</details>