### PR TITLE
Cancel the London December Tech Day

### DIFF
--- a/_events/sr2023/london-tech-day-december.md
+++ b/_events/sr2023/london-tech-day-december.md
@@ -4,7 +4,8 @@ date: 2022-12-03 10:00:00 Europe/London
 end_date: 2022-12-03 17:00:00 Europe/London
 layout: event
 type: tech-day
-location: Thread, Whitechapel
+location: n/a
+cancelled: true
 ---
 
 Tech Days are opportunities for teams to spend a whole day working on their
@@ -15,44 +16,9 @@ We provide a space for you to work in, with power and internet access, as well
 as volunteers able to help you with your kits and hands-on guidance with your
 robots.
 
-At this Tech Day we will have the props available for teams to run through the
-Kickstart [microgames][microgames] if they have not done so already.
+**Due to unforeseen circumstances this Tech Day will not be running in London.**
 
-Due to limited space in the venue, we only have room for six teams at this Tech
-Day. Signup is now closed and teams who have places will have received an email
-confirming their place.
+Instead we are planning to run a [Virtual Tech Day][virtual-tech-day] on the
+Saturday instead.
 
-At the request of the venue: paint, hand tools which create mess, or power tools
-may not be used at this Tech Day.
-
-**Please bring your laptops!**
-
-## Directions
-
-This Tech Day is being held in the [offices of Thread][venue-map] at:
-
-1 Alie Street,<br>
-Whitechapel,<br>
-London,<br>
-E1 8DE
-
-The easiest way to travel will be by public transport — Aldgate, Aldgate East
-and Tower Gateway stations are all within a five minute walk, and Liverpool
-Street station is a ten minute walk away. There are also a large number of
-buses which stop nearby.
-
-Upon arrival at reception, please ask for Thread.
-
-## Schedule
-
-| Time  | Info |
-|-------|------|
-| 10:00 | Doors Open. |
-| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
-| 13:30 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them. |
-| 17:00 | Finish. |
-
-[microgames]: https://studentrobotics.org/docs/tutorials/microgames
-[venue-map]: https://www.google.com/maps/d/edit?mid=1pE5GCb4sxCgY43qFYhNW0w1K6EJ_sCI
-[tech-day-signup]: https://forms.gle/xqUxJ6GFqbJfeJdZ9
-[teams-contact]: mailto:teams@studentrobotics.org
+[virtual-tech-day]: {{ site.base_url }}/events/sr2023/virtual-tech-day-december

--- a/_events/sr2023/virtual-tech-day-december.md
+++ b/_events/sr2023/virtual-tech-day-december.md
@@ -15,7 +15,7 @@ The aim of this day is to help teams out by having guaranteed presence from us
 blueshirts. We'll be around to answer questions about the competition, give kit
 support, assist with the microgames, and assist with strategy ideas.
 
-Our SR2023 December Tech Day is being hosted on our Discord server.
+Our SR2023 December Tech Day is being hosted on our [Discord](https://studentrobotics.org/docs/team_admin/discord) server.
 
 ## Schedule
 

--- a/_events/sr2023/virtual-tech-day-december.md
+++ b/_events/sr2023/virtual-tech-day-december.md
@@ -16,3 +16,14 @@ blueshirts. We'll be around to answer questions about the competition, give kit
 support, assist with the microgames, and assist with strategy ideas.
 
 Our SR2023 December Tech Day is being hosted on our Discord server.
+
+## Schedule
+
+| Time  | Info
+|-------|------
+| 10:00 | Welcome
+| 10:10 | Mentoring from volunteers - working on your robot with a skilled selection of volunteers on hand to mentor. We'll be around to answer questions about the competition, give kit support, and assist with strategy ideas.
+| 12:30 | Lunch
+| 13:30 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them.
+| 14:00 | More mentoring
+| ~17:00 | Finish

--- a/_events/sr2023/virtual-tech-day-december.md
+++ b/_events/sr2023/virtual-tech-day-december.md
@@ -1,0 +1,18 @@
+---
+title: December Virtual Tech Day
+date: 2022-12-03 10:00:00 Europe/London
+end_date: 2022-12-03 17:00:00 Europe/London
+layout: event
+type: tech-day
+location: Discord
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They’re also an opportunity to see how other
+teams are doing or get more direct help with their robots.
+
+The aim of this day is to help teams out by having guaranteed presence from us
+blueshirts. We'll be around to answer questions about the competition, give kit
+support, assist with the microgames, and assist with strategy ideas.
+
+Our SR2023 December Tech Day is being hosted on our Discord server.


### PR DESCRIPTION
This can't go ahead at the planned venue and we don't have time to find another one. We'll run a virtual Tech Day instead.