### PR TITLE
Add the January Virtual Tech Day

### DIFF
--- a/_events/sr2023/virtual-tech-day-january.md
+++ b/_events/sr2023/virtual-tech-day-january.md
@@ -1,0 +1,37 @@
+---
+title: January Virtual Tech Day
+date: 2023-01-07 10:00:00 Europe/London
+end_date: 2023-01-07 20:00:00 Europe/London
+layout: event
+type: tech-day
+location: Discord
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They’re also an opportunity to see how other
+teams are doing or get more direct help with their robots.
+
+The aim of this day is to help teams out by having guaranteed presence from us
+blueshirts. We'll be around to answer questions about the competition, give kit
+support, assist with the microgames, and assist with strategy ideas.
+
+Our SR2023 January Tech Day is being hosted on our [Discord](https://studentrobotics.org/docs/team_admin/discord) server.
+
+This Tech Day leads up to the first [Challenge Submission Deadline][deadline]
+and we anticipate that many teams may find it useful to work on their challenge
+submissions during this Tech Day. Teams are of course welcome to work on
+whatever they choose.
+
+## Schedule
+
+| Time  | Info
+|-------|------
+| 10:00 | Welcome
+| 10:10 | Mentoring from volunteers - working on your robot with a skilled selection of volunteers on hand to mentor. We'll be around to answer questions about the competition, give kit support, and assist with strategy ideas.
+| 12:30 | Lunch
+| 13:30 | Lightning Talks, where teams will talk about their robots and what they plan on doing with them.
+| 14:00 | More mentoring
+| 17:00 | It is likely that there will be fewer mentors in the evening, though there will be mentors around throughout the day.
+| 20:00 | First [Challenge Deadline][deadline] & Finish
+
+[deadline]: {{ site.base_url }}/events/sr2023/first-challenge-submission-deadline/


### PR DESCRIPTION
There may also be an in-person aspect (in Cambridge), though we're definitely going to have a virtual one given the presence of the challenges deadline.