### PR TITLE
Minimal support for Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,6 @@ gem 'html-proofer'
 
 # Avoid polling on windows
 gem 'wdm', '>= 0.1.0'
+
+# For local Ruby 3 support; works around https://github.com/github/pages-gem/issues/752
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     tzinfo-data (1.2018.5)
       tzinfo (>= 1.0.0)
     wdm (0.1.1)
+    webrick (1.7.0)
     yell (2.2.2)
 
 PLATFORMS
@@ -118,6 +119,7 @@ DEPENDENCIES
   tzinfo
   tzinfo-data
   wdm (>= 0.1.0)
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.3.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 task :clean do
   sh('rm -rf _site')
 end
@@ -14,7 +16,13 @@ task :dependencies do
 
   # Fix pathutil on Ruby 3; works around https://github.com/envygeeks/pathutil/pull/5
   # as suggested by https://stackoverflow.com/a/73909894/67873
-  sh('sed -i.bak "s/, kwd/, **kwd/" $(bundle exec gem which pathutil)')
+  pathutil_path = `bundle exec gem which pathutil`.chomp()
+  content = File.read(pathutil_path).gsub(', kwd', ', **kwd')
+  backup_path = '#{pathutil_path}.bak'
+  if File.exist?(backup_path) then
+    FileUtil.mv(pathutil_path, backup_path)
+  end
+  File.write(pathutil_path, content)
 end
 
 task :spelling_dependencies do

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task :dependencies do
   # as suggested by https://stackoverflow.com/a/73909894/67873
   pathutil_path = `bundle exec gem which pathutil`.chomp()
   content = File.read(pathutil_path).gsub(', kwd', ', **kwd')
-  backup_path = '#{pathutil_path}.bak'
+  backup_path = "#{pathutil_path}.bak"
   if File.exist?(backup_path)
     FileUtil.mv(pathutil_path, backup_path)
   end

--- a/Rakefile
+++ b/Rakefile
@@ -18,10 +18,6 @@ task :dependencies do
   # as suggested by https://stackoverflow.com/a/73909894/67873
   pathutil_path = `bundle exec gem which pathutil`.chomp()
   content = File.read(pathutil_path).gsub(', kwd', ', **kwd')
-  backup_path = "#{pathutil_path}.bak"
-  if File.exist?(backup_path)
-    FileUtil.mv(pathutil_path, backup_path)
-  end
   File.write(pathutil_path, content)
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ task :dependencies do
   pathutil_path = `bundle exec gem which pathutil`.chomp()
   content = File.read(pathutil_path).gsub(', kwd', ', **kwd')
   backup_path = '#{pathutil_path}.bak'
-  if File.exist?(backup_path) then
+  if File.exist?(backup_path)
     FileUtil.mv(pathutil_path, backup_path)
   end
   File.write(pathutil_path, content)

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,10 @@ task :dependencies do
     sh('bundle config set --local path "gems"')
   end
   sh('bundle install')
+
+  # Fix pathutil on Ruby 3; works around https://github.com/envygeeks/pathutil/pull/5
+  # as suggested by https://stackoverflow.com/a/73909894/67873
+  sh('sed -i.bak "s/, kwd/, **kwd/" $(bundle exec gem which pathutil)')
 end
 
 task :spelling_dependencies do


### PR DESCRIPTION
This isn't officially supported by Jekyll and is a bit hacky, so I'm deliberately not documenting the support, however as recent Ubuntu versions now ship with Ruby 3 (not 2.7) and Jekyll isn't showing any signs of moving towards supporting Ruby 3 we're not left with many alternatives.

This works around:
- https://github.com/github/pages-gem/issues/752
- https://github.com/envygeeks/pathutil/pull/5

If we're happy with this fix I'll also apply it to our other Jekyll projects (docs, style, competition-website).