### PR TITLE
Fix invalid site.base_url usages

### DIFF
--- a/_events/sr2023/london-tech-day-december.md
+++ b/_events/sr2023/london-tech-day-december.md
@@ -21,4 +21,4 @@ robots.
 Instead we are planning to run a [Virtual Tech Day][virtual-tech-day] on the
 Saturday instead.
 
-[virtual-tech-day]: {{ site.base_url }}/events/sr2023/virtual-tech-day-december
+[virtual-tech-day]: {{ site.baseurl }}/events/sr2023/virtual-tech-day-december

--- a/_events/sr2023/virtual-tech-day-january.md
+++ b/_events/sr2023/virtual-tech-day-january.md
@@ -39,4 +39,4 @@ Our SR2023 January Tech Day is being hosted on our [Discord](https://studentrobo
 | 17:00 | It is likely that there will be fewer mentors in the evening, though there will be mentors around throughout the day.
 | 20:00 | First [Challenge Deadline][deadline] & Finish
 
-[deadline]: {{ site.base_url }}/events/sr2023/first-challenge-submission-deadline/
+[deadline]: {{ site.baseurl }}/events/sr2023/first-challenge-submission-deadline/


### PR DESCRIPTION
Not clear why the HTML & link validation checks didn't pick up on these, especially as these links didn't work locally (even though they do in prod).