### PR TITLE
Add an "add to calendar" button to event pages

### DIFF
--- a/_includes/calendar-button.html
+++ b/_includes/calendar-button.html
@@ -1,0 +1,12 @@
+<add-to-calendar-button
+  name="{{ site.title }}"
+  {% comment %}startDate is required{% endcomment %}
+  startDate="1970-01-01"
+  subscribe
+  icsFile="https://studentrobotics.org/events.ics"
+  iCalFileName="{{ site.title }}"
+  options="'Apple','Google','iCal','Outlook.com','Microsoft 365','Microsoft Teams'"
+  lightMode="system"
+  size="4|4|2"
+  buttonStyle="flat"
+/>

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -1,6 +1,8 @@
 <script src="{{ '/js/main.js' | prepend: site.baseurl }}"></script>
 <script src="{{ '/js/localise-times.js' | prepend: site.baseurl }}"></script>
 
+<script src="https://cdn.jsdelivr.net/npm/add-to-calendar-button@2.1.1/dist/atcb.min.js"></script>
+
 {% if site.user_tracking %}
   <script defer data-domain="studentrobotics.org" src="https://plausible.io/js/plausible.js"></script>
 {% endif %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -1,9 +1,10 @@
 ---
 layout: page
 ---
-<div class="header-card">
+<div class="header-card calendar-button">
   <div class="fixed-width">
     <h1>{{ page.title }}</h1>
+    {% include calendar-button.html %}
   </div>
 </div>
 <div class="main">

--- a/_sass/common.scss
+++ b/_sass/common.scss
@@ -10,7 +10,7 @@
 
   margin: 0 auto;
   padding: 0;
-  // overflow: hidden;
+  overflow: hidden;
 }
 
 .sidebar, main {

--- a/_sass/common.scss
+++ b/_sass/common.scss
@@ -10,7 +10,7 @@
 
   margin: 0 auto;
   padding: 0;
-  overflow: hidden;
+  // overflow: hidden;
 }
 
 .sidebar, main {
@@ -33,6 +33,14 @@
     font-family: $hero-font-family;
     color: $sr-white;
     margin-bottom: 0;
+  }
+
+  &.calendar-button .fixed-width {
+    display: flex;
+    justify-content: space-between;
+    overflow: initial;
+    align-items: center;
+
   }
 }
 

--- a/events.html
+++ b/events.html
@@ -3,9 +3,19 @@ layout: page
 title: Events
 permalink: /events/
 ---
-<div class="header-card">
+<div class="header-card calendar-button">
   <div class="fixed-width">
     <h1>Events</h1>
+    <add-to-calendar-button
+      name="{{ site.title }}"
+      startDate="1970-01-01"
+      subscribe
+      icsFile="https://studentrobotics.org/events.ics"
+      iCalFileName="{{ site.title }}"
+      options="'Apple','Google','iCal','Outlook.com','Microsoft 365','Microsoft Teams'"
+      lightMode="system"
+      size="4|4|2"
+    />
   </div>
 </div>
 <div class="main">

--- a/events.html
+++ b/events.html
@@ -6,16 +6,7 @@ permalink: /events/
 <div class="header-card calendar-button">
   <div class="fixed-width">
     <h1>Events</h1>
-    <add-to-calendar-button
-      name="{{ site.title }}"
-      startDate="1970-01-01"
-      subscribe
-      icsFile="https://studentrobotics.org/events.ics"
-      iCalFileName="{{ site.title }}"
-      options="'Apple','Google','iCal','Outlook.com','Microsoft 365','Microsoft Teams'"
-      lightMode="system"
-      size="4|4|2"
-    />
+    {% include calendar-button.html %}
   </div>
 </div>
 <div class="main">


### PR DESCRIPTION
This adds an "Add to calendar" button to the events list and event page. The buttons always try to embed the full event list, rather than just adding the single event. It's a little misleading, but it ensures the person sees all our future events too.

![image](https://user-images.githubusercontent.com/6527489/217639816-39a769bf-d02b-4001-ba0c-71155fc3c8b2.png)
