### PR TITLE
Add a link to the league leaderboard to the homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,6 +28,13 @@ layout: default
       </div>
     </div>
     <div class="content">
+      <h4>Competition Status</h4>
+      <a href="https://studentrobotics.org/comp/league">Leaderboard</a>
+      <div class="content-details">
+        after the Virtual Competition
+      </div>
+    </div>
+    <div class="content">
       {% assign next_event = site.events | where_exp: "event", "event.date > site.time"
       | where_exp: "event", "event.cancelled != true" | first %}
       <h4>Next Event</h4>


### PR DESCRIPTION
This shows that the virtual competition has happened and that teams have started earning points.

Sam & I also eyeballed:
- putting this new section on the right
- linking "Virtual Competition" (to the event page), and
- adding an `<abbr>` around "Virtual Competition" (with a title saying what it is)

but we think that this probably looks best.

_Proposed_:
![image](https://user-images.githubusercontent.com/336212/222575099-31049f72-cf06-44a5-890c-a85e6b6c2d8d.png)

_with link_:
![image](https://user-images.githubusercontent.com/336212/222575161-da47703d-a0f5-4dc7-9d76-5c556d7a9362.png)

_with `<abbr>`_:
![image](https://user-images.githubusercontent.com/336212/222575235-3261cfcc-4984-45f8-93bd-9f29f92a53bc.png)

_right hand side_:
![image](https://user-images.githubusercontent.com/336212/222575851-813e1bb4-6024-4447-8130-b44c72ac9b2e.png)
