### PR TITLE
Add subresource integrity checking to our user-tracking script

### DIFF
--- a/_includes/script.html
+++ b/_includes/script.html
@@ -2,5 +2,5 @@
 <script src="{{ '/js/localise-times.js' | prepend: site.baseurl }}"></script>
 
 {% if site.user_tracking %}
-  <script defer data-domain="studentrobotics.org" src="https://plausible.io/js/plausible.js"></script>
+  <script defer data-domain="studentrobotics.org" src="https://plausible.io/js/plausible.js" integrity="sha512-2LDEk+a4iJ5KXEkRhnvXOHlC8rfPr5l+VRbP6BVrNsrnByHUWpdsgd4szfmNDZGGzjzD576bLcNYQAjF/4vASQ==" crossorigin="anonymous"></script>
 {% endif %}


### PR DESCRIPTION
If we're going to track users we should at least ensure that the script which does so is what we're expecting. The value here is derived from a manual check of the current version of the file.

I couldn't find anything on Plausible's website about this, so I'm just guessing that this is ok to do. Ideally it feels like we should pin the version of the library we're pulling in, however I couldn't find anything on how to do that either.