### PR TITLE
Add Robots 101 list page

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -8,7 +8,9 @@ layout: page
         <div class="article">
           <div class="article-header">
             <h1>{{ page.title }}</h1>
-            <p class="article-info">Published {{ page.date | date: "%e %B, %Y" }}</p>
+            {% if page.date %}
+              <p class="article-info">Published {{ page.date | date: "%e %B, %Y" }}</p>
+            {% endif %}
           </div>
           <div class="article-content">
             {{ content }}

--- a/_posts/2022-10-07-101-so-youre-a-team-supervisor.md
+++ b/_posts/2022-10-07-101-so-youre-a-team-supervisor.md
@@ -1,11 +1,12 @@
 ---
 title: Robots 101 - So you're running a team
+tags: [robots_101]
 ---
+
+So, you’re running a team. Here’s a little bit of info on what to expect from Student Robotics, and your responsibilities as a team supervisor.
 
 {% include figure.html src="/images/content/blog/robots-101/team-supervisor.jpg"
            caption="One of our SR2022 Team Supervisors" %}
-
-So, you’re running a team. Here’s a little bit of info on what to expect from Student Robotics, and your responsibilities as a team supervisor.
 
 As a team supervisor, your role is to guide the competitors through the journey of building a robot. You’ll be there to point them in the right direction when they get stuck and resolve any issues they run into. We encourage team supervisors to limit their involvement with the robot design/building process so that the finished contraptions are 100% student-built which competitors find very rewarding.
 

--- a/_posts/2022-10-22-101-post-kickstart.md
+++ b/_posts/2022-10-22-101-post-kickstart.md
@@ -1,8 +1,7 @@
 ---
 title: Robots 101 - Kickstarted, now what?
+tags: [robots_101]
 ---
-
-Welcome to the start of Robot 101, our series where we guide you through the competition and give some advice on your next steps.
 
 So, you attended our kickstart event and are now ready to build your robot! But where should you start? We’re here to help!
 

--- a/_posts/2022-12-15-101-robot-design.md
+++ b/_posts/2022-12-15-101-robot-design.md
@@ -1,5 +1,6 @@
 ---
 title: Robots 101 - Robot Design
+tags: [robots_101]
 ---
 
 Welcome back to our Robots 101 series! This time we will be looking at what you need to consider when designing a robot that is both practical for the game’s task and one that would fit our safety regulations.

--- a/_posts/2023-01-19-robot-101-theming.md
+++ b/_posts/2023-01-19-robot-101-theming.md
@@ -1,5 +1,6 @@
 ---
 title: Robots 101 - Theming
+tags: [robots_101]
 ---
 
 Welcome (back) to the Robots 101 series! This time, we’re addressing theming

--- a/blog/robots-101.html
+++ b/blog/robots-101.html
@@ -1,0 +1,20 @@
+---
+layout: blog
+title: Robots 101
+---
+
+<p>Welcome to Robot 101, our series where we guide you through the competition and give some advice on your next steps.</p>
+
+{% for page in site.tags.robots_101 %}
+  {% include get_description_for_page.html %}
+
+  <div class="article article-preview card">
+    <div class="article-header">
+      <h1><a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a></h1>
+      <p class="article-info">Published {{ page.date | date: "%e %B, %Y" }}</p>
+    </div>
+    <div class="article-content">
+      {{ description }}
+    </div>
+  </div>
+{% endfor %}


### PR DESCRIPTION
For pointing supervisors how to get started, our "Robots 101" series is great, but there currently it's a way to link them to the entire series of posts.

This leans on Jekyll's tag functionality, and uses a custom list page to show the posts. To keep the page smaller, only the page description is shown.

![image](https://github.com/srobo/website/assets/6527489/4f396711-16de-408e-93fe-76129aec74da)

Opening early for feedback, there's probably more polish which could be done.