### PR TITLE
Remove competition pages link from the homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,13 +28,6 @@ layout: default
       </div>
     </div>
     <div class="content">
-      <h4>Competition Status</h4>
-      <a href="https://studentrobotics.org/comp/league">Leaderboard</a>
-      <div class="content-details">
-        after the Competition
-      </div>
-    </div>
-    <div class="content">
       {% assign next_event = site.events | where_exp: "event", "event.date > site.time"
       | where_exp: "event", "event.cancelled != true" | first %}
       <h4>Next Event</h4>


### PR DESCRIPTION
While we could make this configurable, we don't know what we'll want this to say next year given that it was a new thing this year. Removal is therefore the simplest way to decouple the comp pages (thus enabling the shutdown of the srcomp machine) and it's still easy to get this back from the history if we do want it.

Closes #501 