### PR TITLE
Apply consistent styling to lists in articles

### DIFF
--- a/_sass/blog.scss
+++ b/_sass/blog.scss
@@ -60,7 +60,7 @@
     }
   }
 
-  ul {
+  ul, ol {
     margin: 1.2em 0 1.2em 40px;
 
     li {


### PR DESCRIPTION
This applies the styling we have for unordered lists to ordered lists too, allowing either style to be used within articles.

Previously ordered lists' elements were collapsed together and their numbers were invisible (pushed outside their container to the left).

## Before
![image](https://github.com/srobo/website/assets/336212/29236310-aacf-4d2b-a594-d28131413c5c)

## After
![image](https://github.com/srobo/website/assets/336212/da1763da-c6a8-491f-8637-7ecf41b97c48)
