### PR TITLE
Add Tech Day events for SR2024

### DIFF
--- a/_events/sr2024/cambridge-tech-day-march.md
+++ b/_events/sr2024/cambridge-tech-day-march.md
@@ -1,0 +1,32 @@
+---
+title: Cambridge March Tech Day
+date: 2024-03-02 10:00:00 Europe/London
+end_date: 2024-03-02 17:00:00 Europe/London
+layout: event
+type: tech-day
+location: Raspberry Pi Foundation, Cambridge
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They're also an opportunity to see how other
+teams are doing or get more direct help with your robots.
+
+We provide a space for you to work in, with power and internet access, as well
+as volunteers able to help you with your kits and hands-on guidance with your
+robots.
+
+Spaces are limited to six teams, so be sure to [let us know][tech-day-signup] by
+Friday 23rd February 2024 if you'd like to attend.  We will begin confirming
+places from Wednesday 31st January 2024.
+
+**Please bring your laptops!**
+
+## Schedule
+
+| Time  | Info |
+|-------|------|
+| 10:00 | Doors Open. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 17:00 | Finish. |
+
+[tech-day-signup]: https://forms.gle/orwWr8DBkMg2CVTf9

--- a/_events/sr2024/cambridge-tech-day-march.md
+++ b/_events/sr2024/cambridge-tech-day-march.md
@@ -26,7 +26,7 @@ places from Wednesday 31st January 2024.
 | Time  | Info |
 |-------|------|
 | 10:00 | Doors Open. |
-| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venue. |
 | 17:00 | Finish. |
 
 [tech-day-signup]: https://forms.gle/orwWr8DBkMg2CVTf9

--- a/_events/sr2024/horsham-tech-day-january.md
+++ b/_events/sr2024/horsham-tech-day-january.md
@@ -40,7 +40,7 @@ Upon arrival please buzz for Red River Software.
 | Time  | Info |
 |-------|------|
 | 10:00 | Doors Open. |
-| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venue. |
 | 17:00 | Finish. |
 
 [venue-map]: https://goo.gl/maps/ci33utzx4iQhm5bR7

--- a/_events/sr2024/horsham-tech-day-january.md
+++ b/_events/sr2024/horsham-tech-day-january.md
@@ -1,0 +1,47 @@
+---
+title: Horsham January Tech Day
+date: 2024-01-20 10:00:00 Europe/London
+end_date: 2024-01-20 17:00:00 Europe/London
+layout: event
+type: tech-day
+location: Red River Software, Horsham
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They're also an opportunity to see how other
+teams are doing or get more direct help with your robots.
+
+We provide a space for you to work in, with power and internet access, as well
+as volunteers able to help you with your kits and hands-on guidance with your
+robots.
+
+Spaces are limited to four teams, so be sure to [let us know][tech-day-signup]
+by Friday 12th January 2024 if you'd like to attend. We will begin confirming
+places from Wednesday 13th December 2023.
+
+**Please bring your laptops!**
+
+## Directions
+
+This Tech Day is being held in the [offices of Red River Software][venue-map]
+at:
+
+Red River Software,<br>
+Springfield House,<br>
+Horsham,<br>
+RH12 2RG
+
+We may be able to provide parking if necessary, please let us know on the sign up form if this is needed.
+
+Upon arrival please buzz for Red River Software.
+
+## Schedule
+
+| Time  | Info |
+|-------|------|
+| 10:00 | Doors Open. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 17:00 | Finish. |
+
+[venue-map]: https://goo.gl/maps/ci33utzx4iQhm5bR7
+[tech-day-signup]: https://forms.gle/orwWr8DBkMg2CVTf9

--- a/_events/sr2024/horsham-tech-day-november.md
+++ b/_events/sr2024/horsham-tech-day-november.md
@@ -1,0 +1,48 @@
+---
+title: Horsham November Tech Day
+date: 2023-11-04 10:00:00 Europe/London
+end_date: 2023-11-04 17:00:00 Europe/London
+layout: event
+type: tech-day
+location: Red River Software, Horsham
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They're also an opportunity to see how other
+teams are doing or get more direct help with your robots.
+
+We provide a space for you to work in, with power and internet access, as well
+as volunteers able to help you with your kits and hands-on guidance with your
+robots.
+
+Spaces are limited to four teams, so be sure to [let us know][tech-day-signup]
+by Friday 27th October 2023 if you'd like to attend. We will be allocating and
+confirming places as we receive applications, so sign up soon to avoid
+disappointment.
+
+**Please bring your laptops!**
+
+## Directions
+
+This Tech Day is being held in the [offices of Red River Software][venue-map]
+at:
+
+Red River Software,<br>
+Springfield House,<br>
+Horsham,<br>
+RH12 2RG
+
+We may be able to provide parking if necessary, please let us know on the sign up form if this is needed.
+
+Upon arrival please buzz for Red River Software.
+
+## Schedule
+
+| Time  | Info |
+|-------|------|
+| 10:00 | Doors Open. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 17:00 | Finish. |
+
+[venue-map]: https://goo.gl/maps/ci33utzx4iQhm5bR7
+[tech-day-signup]: https://forms.gle/orwWr8DBkMg2CVTf9

--- a/_events/sr2024/horsham-tech-day-november.md
+++ b/_events/sr2024/horsham-tech-day-november.md
@@ -41,7 +41,7 @@ Upon arrival please buzz for Red River Software.
 | Time  | Info |
 |-------|------|
 | 10:00 | Doors Open. |
-| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venue. |
 | 17:00 | Finish. |
 
 [venue-map]: https://goo.gl/maps/ci33utzx4iQhm5bR7

--- a/_events/sr2024/southampton-tech-day-december.md
+++ b/_events/sr2024/southampton-tech-day-december.md
@@ -31,7 +31,7 @@ At the request of the venue:
 | Time  | Info |
 |-------|------|
 | 10:00 | Doors Open. |
-| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venue. |
 | 17:00 | Finish. |
 
 [tech-day-signup]: https://forms.gle/orwWr8DBkMg2CVTf9

--- a/_events/sr2024/southampton-tech-day-december.md
+++ b/_events/sr2024/southampton-tech-day-december.md
@@ -1,0 +1,37 @@
+---
+title: Southampton December Tech Day
+date: 2023-12-09 10:00:00 Europe/London
+end_date: 2023-12-09 17:00:00 Europe/London
+layout: event
+type: tech-day
+location: University of Southampton, room <abbr title="to be confirmed">TBC</abbr>
+---
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They're also an opportunity to see how other
+teams are doing or get more direct help with your robots.
+
+We provide a space for you to work in, with power and internet access, as well
+as volunteers able to help you with your kits and hands-on guidance with your
+robots.
+
+Please [let us know][tech-day-signup] by Friday 1st December 2023 if you'd like
+to attend. We will begin confirming places from Wednesday 8th November 2023.
+
+At the request of the venue:
+
+* any electrical equipment must be PAT tested,
+* paint may not be used, and
+* soldering irons may not be used
+
+**Please bring your laptops!**
+
+## Schedule
+
+| Time  | Info |
+|-------|------|
+| 10:00 | Doors Open. |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venues. |
+| 17:00 | Finish. |
+
+[tech-day-signup]: https://forms.gle/orwWr8DBkMg2CVTf9


### PR DESCRIPTION
This features:
- all four tech days for the year
- signup deadlines & form links, allowing the teams to sign up anything up to a week before the event
- a commitment to confirm places (mostly) over a month before the event; the exception is the first tech day since we don't have that much time between then & now
- no mention of lightning talks -- we can do these ad-hoc if they seem useful

Known outstanding to be added as we get more details (later in the year):
- room TBC in Southampton
- more details on the precise location in Cambridge