### PR TITLE
Update all YouTube embeds to preserve user privacy

### DIFF
--- a/_events/sr2020/virtual-competition-knockouts.md
+++ b/_events/sr2020/virtual-competition-knockouts.md
@@ -12,4 +12,4 @@ Code submission will be due at 10am BST: [Submit your code](https://studentrobot
 
 Our livestream will start at 3pm BST: [Watch live](https://youtu.be/xBPVqsb_Ydk)
 
-<iframe title="Livestream of the Knockouts and Final" width="100%" height="315" src="https://www.youtube.com/embed/xBPVqsb_Ydk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the Knockouts and Final" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/xBPVqsb_Ydk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2020/virtual-competition-league-1.md
+++ b/_events/sr2020/virtual-competition-league-1.md
@@ -12,4 +12,4 @@ Code submission will be due at 10am BST: [Submit your code](https://studentrobot
 
 Our livestream will start at 3pm BST: [Watch live](https://youtu.be/xLL7SoQywf4)
 
-<iframe title="Livestream of the first League Session" width="100%" height="315" src="https://www.youtube.com/embed/xLL7SoQywf4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the first League Session" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/xLL7SoQywf4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2020/virtual-competition-league-2.md
+++ b/_events/sr2020/virtual-competition-league-2.md
@@ -12,4 +12,4 @@ Code submission will be due at 10am BST: [Submit your code](https://studentrobot
 
 Our livestream will start at 3pm BST: [Watch live](https://youtu.be/7JoW4zXSeZE)
 
-<iframe title="Livestream of the second League Session" width="100%" height="315" src="https://www.youtube.com/embed/7JoW4zXSeZE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the second League Session" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/7JoW4zXSeZE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2020/virtual-competition-league-3.md
+++ b/_events/sr2020/virtual-competition-league-3.md
@@ -12,4 +12,4 @@ Code submission will be due at 10am BST: [Submit your code](https://studentrobot
 
 Our livestream will start at 3pm BST: [Watch live](https://youtu.be/symUE1E4niI)
 
-<iframe title="Livestream of the third League Session" width="100%" height="315" src="https://www.youtube.com/embed/symUE1E4niI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the third League Session" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/symUE1E4niI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2020/virtual-competition-league-4.md
+++ b/_events/sr2020/virtual-competition-league-4.md
@@ -12,4 +12,4 @@ Code submission will be due at 10am BST: [Submit your code](https://studentrobot
 
 Our livestream will start at 3pm BST: [Watch live](https://youtu.be/Y4h5P47j8jM)
 
-<iframe title="Livestream of the fourth League Session" width="100%" height="315" src="https://www.youtube.com/embed/Y4h5P47j8jM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the fourth League Session" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/Y4h5P47j8jM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2021/kickstart.md
+++ b/_events/sr2021/kickstart.md
@@ -23,6 +23,6 @@ There's still time to [sign up][sign-up] if you have't already! Deadline for ent
 
 Our livestream will start at 1pm GMT: [Watch live](https://www.youtube.com/watch?v=cQOgo0Gh4iA)
 
-<iframe title="Livestream of the Kickstart event" width="100%" height="315" src="https://www.youtube.com/embed/cQOgo0Gh4iA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the Kickstart event" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/cQOgo0Gh4iA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 [sign-up]: {{ site.baseurl }}/compete/

--- a/_events/sr2021/knockouts.md
+++ b/_events/sr2021/knockouts.md
@@ -14,7 +14,7 @@ Teams will have to submit their code to us by 8pm BST on Friday 30th April using
   title="Livestream of the Knockouts and Final"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/gxJM6ernMqo"
+  src="https://www.youtube-nocookie.com/embed/gxJM6ernMqo"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen

--- a/_events/sr2021/league-1.md
+++ b/_events/sr2021/league-1.md
@@ -16,7 +16,7 @@ Our livestream will start at noon GMT: [Watch live](https://www.youtube.com/watc
   title="Livestream of the first League Session"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/cAvk-nfTUis"
+  src="https://www.youtube-nocookie.com/embed/cAvk-nfTUis"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen

--- a/_events/sr2021/league-2.md
+++ b/_events/sr2021/league-2.md
@@ -14,7 +14,7 @@ Teams will have to submit their code to us by 8pm GMT on Friday 5th using our [c
   title="Livestream of the second League Session"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/RwW5Oz30gbE"
+  src="https://www.youtube-nocookie.com/embed/RwW5Oz30gbE"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen

--- a/_events/sr2021/league-3.md
+++ b/_events/sr2021/league-3.md
@@ -14,7 +14,7 @@ Teams will have to submit their code to us by 8pm GMT on Friday 19th using our [
   title="Livestream of the third League Session"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/MpuhtW4mCKM"
+  src="https://www.youtube-nocookie.com/embed/MpuhtW4mCKM"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen

--- a/_events/sr2021/league-4.md
+++ b/_events/sr2021/league-4.md
@@ -14,7 +14,7 @@ Teams will have to submit their code to us by 8pm BST on Friday 23rd using our [
   title="Livestream of the fourth League Session"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/E9gF-GZbf5M"
+  src="https://www.youtube-nocookie.com/embed/E9gF-GZbf5M"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen

--- a/_events/sr2022/competition.md
+++ b/_events/sr2022/competition.md
@@ -89,7 +89,7 @@ Please see our [COVID-19 updates]({{ '/covid-19' | prepend: site.baseurl }}) pag
   title="SR2022 Competition Day 1"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/7HNG2bqwXlo"
+  src="https://www.youtube-nocookie.com/embed/7HNG2bqwXlo"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
@@ -101,7 +101,7 @@ Please see our [COVID-19 updates]({{ '/covid-19' | prepend: site.baseurl }}) pag
   title="SR2022 Competition Day 2"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/M3stcLPbHOU"
+  src="https://www.youtube-nocookie.com/embed/M3stcLPbHOU"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen

--- a/_events/sr2022/kickstart.md
+++ b/_events/sr2022/kickstart.md
@@ -18,7 +18,7 @@ There's still time to [sign up][sign-up] if you haven't already!
 
 Our livestream will start at 1pm GMT: [Watch live](https://www.youtube.com/watch?v=QdZSiUWU4Sk)
 
-<iframe title="Livestream of the Kickstart Event" width="100%" height="315" src="https://www.youtube.com/embed/QdZSiUWU4Sk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the Kickstart Event" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/QdZSiUWU4Sk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Stay tuned for further details!
 

--- a/_events/sr2023/competition.md
+++ b/_events/sr2023/competition.md
@@ -85,7 +85,7 @@ Please see our [COVID-19 updates]({{ '/covid-19' | prepend: site.baseurl }}) pag
   title="SR2023 Competition Day 1"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/TxbfE9es-EY"
+  src="https://www.youtube-nocookie.com/embed/TxbfE9es-EY"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
@@ -97,7 +97,7 @@ Please see our [COVID-19 updates]({{ '/covid-19' | prepend: site.baseurl }}) pag
   title="SR2023 Competition Day 2"
   width="100%"
   height="315"
-  src="https://www.youtube.com/embed/Z3Y-bUSGw34"
+  src="https://www.youtube-nocookie.com/embed/Z3Y-bUSGw34"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen

--- a/_events/sr2023/southampton-kickstart.md
+++ b/_events/sr2023/southampton-kickstart.md
@@ -48,4 +48,4 @@ Southampton's information on [getting to our campuses][soton-campus-directions]
 
 Our livestream will start at <time datetime="2023-10-22T10:00:00+01:00" title="Sun, 22 Oct 2023 10:00:00 +0100">10am UK time</time>: [Watch live](https://www.youtube.com/watch?v=FVnNv5GSpyQ)
 
-<iframe title="Livestream of the Kickstart Event" width="100%" height="315" src="https://www.youtube.com/embed/FVnNv5GSpyQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the Kickstart Event" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/FVnNv5GSpyQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_events/sr2023/virtual-competition.md
+++ b/_events/sr2023/virtual-competition.md
@@ -13,6 +13,6 @@ Teams will have to submit their code to us by 8pm GMT on Friday 24th using our [
 
 ## Livestream
 
-<iframe title="Livestream of the virtual competition" width="100%" height="315" src="https://www.youtube.com/embed/mTJGOhwmLPo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="Livestream of the virtual competition" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/mTJGOhwmLPo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 [Watch Live](https://www.youtube.com/watch?v=mTJGOhwmLPo)

--- a/_posts/2019-04-09-sr2019-tlc-crowned-champion.md
+++ b/_posts/2019-04-09-sr2019-tlc-crowned-champion.md
@@ -47,7 +47,7 @@ Student Robotics 2019 concluded with an intense match between [Peter Symonds Col
 <iframe
   title="Video of SR2019 Final"
   class="center video"
-  src="https://www.youtube.com/embed/gOeP96OngE0"
+  src="https://www.youtube-nocookie.com/embed/gOeP96OngE0"
   frameborder="0"
   width="100%"
   allowfullscreen

--- a/_posts/2022-05-03-sr2022-hrs-wins-sr2022.md
+++ b/_posts/2022-05-03-sr2022-hrs-wins-sr2022.md
@@ -78,7 +78,7 @@ Queen Mary’s College taking second place and Brockenhurst College third.
 <iframe
   title="Video of SR2022 Final"
   class="center video"
-  src="https://www.youtube.com/embed/xiDS58Htuh4"
+  src="https://www.youtube-nocookie.com/embed/xiDS58Htuh4"
   frameborder="0"
   width="100%"
   allowfullscreen


### PR DESCRIPTION
We should default to the privacy-prreserving embed over plain youtube.com as users generally don't have a way to control this themselves.