### PR TITLE
Fix the link to the image for the page

### DIFF
--- a/_posts/2023-04-09-haberdashers-win-sr2023.md
+++ b/_posts/2023-04-09-haberdashers-win-sr2023.md
@@ -1,6 +1,6 @@
 ---
 title: Haberdashers' School wins Student Robotics Competition 2023!
-image: /images/content/blog/sr2022/sr2023-photo.jpg
+image: /images/content/blog/sr2023/sr2023-photo.jpg
 image_alt: All the teams from SR2023
 description: SR2023 came to an exciting conclusion with a victory for Haberdashers' School
 ---


### PR DESCRIPTION
This is used in our header tags but not currently on the page itself, so this would have been affecting social media previews of the article.