### PR TITLE
Add media links to the SR2024 blog post

### DIFF
--- a/_posts/2024-04-18-mai-win-sr2024.md
+++ b/_posts/2024-04-18-mai-win-sr2024.md
@@ -129,7 +129,7 @@ The playlists for the soundtrack to the competition are also available:
 - [Epic Playlist](https://open.spotify.com/playlist/36E9z8CIs87FacZOPaWpkX)
 - [_Chill_ Playlist](https://open.spotify.com/playlist/5z4XkLzR5yokLU0aVlbvDh)
 
-<!--- TODO(post-publish): add link to the photo album here -->
+Photos of the event have been added to our [Google Photos Album](https://photos.app.goo.gl/7iKHjRvA8gny7sCm8).
 
 ## Thank You
 

--- a/_posts/2024-04-18-mai-win-sr2024.md
+++ b/_posts/2024-04-18-mai-win-sr2024.md
@@ -117,6 +117,18 @@ Through social media, teams can share the problems they’re facing as well as t
 
 Check out the [rulebook][rules] for all the details on the awards we give.
 
+## Media
+
+If you would like to watch the competition back, the event was livestreams are available on our [YouTube Channel][sr-youtube]:
+
+- Saturday, Day 1: <https://youtu.be/XhEUXg2m31k>
+- Sunday, Day 2: <https://youtu.be/CpCC2fTn0os>
+
+The playlists for the soundtrack to the competition are also available:
+
+- [Epic Playlist](https://open.spotify.com/playlist/36E9z8CIs87FacZOPaWpkX)
+- [_Chill_ Playlist](https://open.spotify.com/playlist/5z4XkLzR5yokLU0aVlbvDh)
+
 <!--- TODO(post-publish): add link to the photo album here -->
 
 ## Thank You
@@ -162,6 +174,7 @@ If you would like to find out more, please [get in touch][contactus].
 
 _The SR Team_
 
+[sr-youtube]: https://www.youtube.com/StudentRobotics
 [volunteers]: {{ '/volunteer' | prepend: site.baseurl }}
 [contactus]: mailto:pr@studentrobotics.org
 [rules]: https://studentrobotics.org/docs/resources/2024/rulebook.html


### PR DESCRIPTION
This adds the media links we have so far, while establishing a section into which we can add the photo album link when we have that.