### PR TITLE
Collapse list element margins in articles

### DIFF
--- a/_sass/blog.scss
+++ b/_sass/blog.scss
@@ -64,7 +64,7 @@
     margin: 1.2em 0 1.2em 40px;
 
     li {
-      margin: 0.8em 0;
+      margin: 0.3em 0;
     }
   }
 


### PR DESCRIPTION
The current margins are excessive and cause lists to take up a lot more space than they really need to.

New:
![image](https://github.com/srobo/website/assets/336212/fc21f277-b4a1-455d-ad16-a5efa1debaaa)

Current:
![image](https://github.com/srobo/website/assets/336212/1ced694b-5624-4726-a4d6-31aab95dcadc)
