### PR TITLE
Remove reference to closed competition

### DIFF
--- a/compete.html
+++ b/compete.html
@@ -140,9 +140,6 @@ permalink: /compete/
       <a name="signup"></a><h2>Want to compete?</h2>
       <div class="column m-8-12 m-offset-2-12 text-left">
         <p>
-          Registration for the Student Robotics 2024 competition has now closed.
-        </p>
-        <p>
           If you would like to register your interest in applying for a place in
           a future competition, please enter your details below and we'll
           contact you once applications for next year's competition have opened.


### PR DESCRIPTION
THis could be construde as the competition _starting_ in 2024.

In future, we should remove this earlier.