### PR TITLE
Add CI jobs to diff against the deployed version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,51 @@ jobs:
         run: sed -i -r '1 s_<updated>[^/]+</updated>_<updated>NOW</updated>_' {main,local}/feed.xml
 
       - name: Diff
-        run: diff -ru main local
+        id: diff
+        run: |
+          set +e
+          diff -ru main local > ./result.diff
+          result=$?
+          set -euo pipefail
+
+          delimiter="gha-delim-$RANDOM-$RANDOM-gha-delim"
+          {
+            echo "diff<<${delimiter}"
+            cat ./result.diff
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+          cat ./result.diff
+
+          if [[ $result -ne 0 ]]
+          then
+            echo has-changes=true >> "$GITHUB_OUTPUT"
+          else
+            echo has-changes=false >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build comment
+        id: build-comment
+        if: always()
+        run: |
+          {
+            if [[ "${{ steps.diff.outputs.has-changes }}" = "true" ]]
+            then
+              echo "🔀 Build diff:"
+              echo '```diff'
+              cat ./result.diff
+              echo '```'
+            else
+              echo "Build has no changes."
+            fi
+          } > ./comment.md
+
+      - name: Post diff to PR
+        uses: thollander/actions-comment-pull-request@v2
+        if: always()
+        with:
+          comment_tag: build-diff
+          filePath: ./comment.md
 
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
 
   changes:
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     outputs:
       build-system: ${{ steps.filter.outputs.build-system }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,12 +49,41 @@ jobs:
               - Gemfile*
               - Rakefile
 
+  build-main:
+    needs:
+      - changes
+    if: needs.changes.outputs.build-system == 'true'
+    env:
+      # ruby/setup-ruby@v1 does not offer a way to change the cached gems path.
+      # See https://github.com/ruby/setup-ruby/issues/291
+      GLOBAL_GEMS: 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          submodules: recursive
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          cache-version: 2
+
+      - name: Build
+        run: rake build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-from-main
+          path: _site
+
   diff:
     runs-on: ubuntu-latest
     needs:
-      - changes
       - build
-    if: needs.changes.outputs.build-system == 'true'
+      - build-main
     steps:
       - name: Download local artefact
         uses: actions/download-artifact@v4
@@ -69,27 +98,17 @@ jobs:
           popd
           mv artifact.tar local.tar
 
-      - name: Download deployed artefact
-        uses: dawidd6/action-download-artifact@v3
+      - name: Download main branch build artifact
+        uses: actions/download-artifact@v4
         with:
-          name: github-pages
-          branch: main
-          path: deployed
-          allow_forks: false
-
-      - name: Unpack deployed
-        run: |
-          mkdir deployed
-          pushd deployed
-          tar --extract --file ../artifact.tar
-          popd
-          mv artifact.tar deployed.tar
+          name: build-from-main
+          path: main
 
       - name: Debug
         run: ls -lR
 
       - name: Diff
-        run: diff -ru deployed local
+        run: diff -ru main local
 
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,64 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
 
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      build-system: ${{ steps.filter.outputs.build-system }}
+    steps:
+      - name: Check if build system changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            build-system:
+              - _config.yml
+              - .github/**/*
+              - Gemfile*
+              - Rakefile
+
+  diff:
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - build
+    if: needs.changes.outputs.build-system == 'true'
+    steps:
+      - name: Download local artefact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
+
+      - name: Unpack local
+        run: |
+          mkdir local
+          pushd local
+          tar --extract --file ../artifact.tar
+          popd
+          mv artifact.tar local.tar
+
+      - name: Download deployed artefact
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          name: github-pages
+          branch: main
+          path: deployed
+          allow_forks: false
+
+      - name: Unpack deployed
+        run: |
+          mkdir deployed
+          pushd deployed
+          tar --extract --file ../artifact.tar
+          popd
+          mv artifact.tar deployed.tar
+
+      - name: Debug
+        run: ls -lR
+
+      - name: Diff
+        run: diff -ru deployed local
+
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Build
         run: rake build
 
-      - name: Upload Pages artifact
+      - name: Upload build site
         uses: actions/upload-artifact@v4
         with:
           name: build-from-main
@@ -86,12 +86,12 @@ jobs:
       - build
       - build-main
     steps:
-      - name: Download local artefact
+      - name: Download artifact from this branch's build
         uses: actions/download-artifact@v4
         with:
           name: github-pages
 
-      - name: Unpack local
+      - name: Unpack local build
         run: |
           mkdir local
           pushd local
@@ -99,7 +99,7 @@ jobs:
           popd
           mv artifact.tar local.tar
 
-      - name: Download main branch build artifact
+      - name: Download artifact from main branch build
         uses: actions/download-artifact@v4
         with:
           name: build-from-main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,8 +105,8 @@ jobs:
           name: build-from-main
           path: main
 
-      - name: Debug
-        run: ls -lR
+      - name: Replace build timestamps
+        run: sed -i -r '1 s_<updated>[^/]+</updated>_<updated>NOW</updated>_' {main,local}/feed.xml
 
       - name: Diff
         run: diff -ru main local


### PR DESCRIPTION
This is expected to be useful when updating dependencies, to ensure that nothing unexpected has changed, or when otherwise making changes to the build system (for the same reason).