### PR TITLE
Mention laptops in the kickstart event

### DIFF
--- a/_events/sr2025/kickstart.md
+++ b/_events/sr2025/kickstart.md
@@ -40,6 +40,7 @@ attendance at Kickstart.
 
 * Your robot kit (we intend to ship kits to teams ahead of Kickstart)
 * Any tools which might be useful to work with your kit
+* A laptop to program your robots with
 
 ## Directions
 


### PR DESCRIPTION
As we won't have iSolutions machines, we need to mention they need to bring laptops