### PR TITLE
Revert "Remove competition pages link from the homepage"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -107,7 +107,9 @@ sponsors:
     logo_width: 200px
 
 user_tracking: true
+
 show_competition_status: true
+competition_status_previous_event: Virtual League
 
 exclude:
   - README.md

--- a/_config.yml
+++ b/_config.yml
@@ -107,6 +107,7 @@ sponsors:
     logo_width: 200px
 
 user_tracking: true
+show_competition_status: true
 
 exclude:
   - README.md

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,6 +28,13 @@ layout: default
       </div>
     </div>
     <div class="content">
+      <h4>Competition Status</h4>
+      <a href="https://studentrobotics.org/comp/league">Leaderboard</a>
+      <div class="content-details">
+        after the Competition
+      </div>
+    </div>
+    <div class="content">
       {% assign next_event = site.events | where_exp: "event", "event.date > site.time"
       | where_exp: "event", "event.cancelled != true" | first %}
       <h4>Next Event</h4>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -27,13 +27,15 @@ layout: default
         {{ latest_post.date | date: "%e %B, %Y" }}
       </div>
     </div>
-    <div class="content">
-      <h4>Competition Status</h4>
-      <a href="https://studentrobotics.org/comp/league">Leaderboard</a>
-      <div class="content-details">
-        after the Competition
+    {% if site.show_competition_status %}
+      <div class="content">
+        <h4>Competition Status</h4>
+        <a href="https://studentrobotics.org/comp/league">Leaderboard</a>
+        <div class="content-details">
+          after the Competition
+        </div>
       </div>
-    </div>
+    {% endif %}
     <div class="content">
       {% assign next_event = site.events | where_exp: "event", "event.date > site.time"
       | where_exp: "event", "event.cancelled != true" | first %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -32,7 +32,7 @@ layout: default
         <h4>Competition Status</h4>
         <a href="https://studentrobotics.org/comp/league">Leaderboard</a>
         <div class="content-details">
-          after the Virtual League
+          after the {{ site.competition_status_previous_event }}
         </div>
       </div>
     {% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -32,7 +32,7 @@ layout: default
         <h4>Competition Status</h4>
         <a href="https://studentrobotics.org/comp/league">Leaderboard</a>
         <div class="content-details">
-          after the Competition
+          after the Virtual League
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
This reverts commit 46027af0d05219142fb9a2cbc335de92e403fb41.

Add a link back to the competition website for match details.

This also makes it configurable for easier future use.