### PR TITLE
Update the competition status label

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -104,7 +104,7 @@ sponsors:
 user_tracking: true
 
 show_competition_status: true
-competition_status_previous_event: Virtual League
+competition_status_previous_event: SR2025 Competition
 
 exclude:
   - README.md


### PR DESCRIPTION
When this page is next seen, it'll be after the physical competition.

See also https://github.com/srobo/ansible/pull/97.