### PR TITLE
Prepare website for SR2026

### DIFF
--- a/_events/sr2026/kickstart.md
+++ b/_events/sr2026/kickstart.md
@@ -1,0 +1,67 @@
+---
+title: Kickstart
+date: 2025-11-08 11:00:00 Europe/London
+end_date: 2025-11-08 17:00:00 Europe/London
+layout: event
+type: kickstart
+location: Southampton University and <a href="https://www.youtube.com/watch?v=waO2NASj1zs">Student Robotics' YouTube Channel</a>
+---
+
+Kickstart is the event which kicks off a competition year.
+The structure of the competition and the game rules will be announced and of course any questions you have will be answered.
+
+Throughout the day we'll have Blueshirts (our awesome volunteers!) around in person, ready to answer any questions you may have and to help you through the microgames.
+These microgames will help your team become familiar with the Kit you've been provided and should kickstart some ideas for your robot's design.
+
+We will also be live streaming the event for those unable to attend in person.
+
+We will soon post some pre-kickstart activities to get started with ahead of Kickstart.
+
+Please [let us know][teams-contact] if your plans change regarding your
+attendance at Kickstart.
+
+## Schedule
+
+| Time  | Info                                                                                                            |
+| ----- | --------------------------------------------------------------------------------------------------------------- |
+| 11:00 | Introductory presentation, where the game of SR2025 will be announced.                                          |
+| 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venue. |
+| 13:30 | Microgames, a set of tasks to familiarise you with the kit.                                                     |
+| 17:00 | Finish.                                                                                                         |
+
+## What to bring
+
+- Any tools which might be useful to work with your kit, especially wire cutters and strippers
+- A laptop to program your robots with, note that the USB stick for your robot needs a [USB Type-A socket](https://www.viewsonic.com/library/tech/usb-c-usb-b-and-usb-a-whats-the-difference/#USB_The_Basics)
+
+We'll be issuing kits to teams at Kickstart. If you're not attending Kickstart, we will ship your kit to you.
+
+## Directions
+
+Kickstart is being held at the University of Southampton at:
+
+Building 46,<br>
+University Road,<br>
+Southampton,<br>
+SO17 1BJ
+
+For public transport or driving instructions, see the University of
+Southampton's information on [getting to our campuses][soton-campus-directions]
+(click the 'Campus map and directions' tab).
+
+## Livestream
+
+Our livestream will start at <time datetime="2025-11-08T11:00:00+01:00" title="Sat, 9 Nov 2025 11:00:00 +0100">11am UK time</time>: Watch link TBC.<br>
+If you can't watch live, you can watch the stream back afterwards.
+
+<iframe
+  title="Livestream of the Kickstart Event"
+  width="100%"
+  height="315"
+  src="https://www.youtube-nocookie.com/embed/waO2NASj1zs"
+  frameborder="0"
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen></iframe>
+
+[teams-contact]: mailto:teams@studentrobotics.org
+[soton-campus-directions]: https://www.southampton.ac.uk/student-life/campuses/highfield

--- a/_events/sr2026/kickstart.md
+++ b/_events/sr2026/kickstart.md
@@ -24,7 +24,7 @@ attendance at Kickstart.
 
 | Time  | Info                                                                                                            |
 | ----- | --------------------------------------------------------------------------------------------------------------- |
-| 11:00 | Introductory presentation, where the game of SR2025 will be announced.                                          |
+| 11:00 | Introductory presentation, where the game of SR2026 will be announced.                                          |
 | 12:30 | There will be a lunch break. Teams should bring their own lunches or get them from food vendors near the venue. |
 | 13:30 | Microgames, a set of tasks to familiarise you with the kit.                                                     |
 | 17:00 | Finish.                                                                                                         |

--- a/_posts/2025-09-06-sr2026-registration-open.md
+++ b/_posts/2025-09-06-sr2026-registration-open.md
@@ -1,0 +1,53 @@
+---
+title: Registration opens for Student Robotics 2026
+---
+
+{% include figure.html src="/images/content/blog/sr2024/sr2024-photo.jpg"
+           caption="All the teams from SR2024" %}
+
+We're excited to announce that registration for the 2026 season of Student
+Robotics is now open!
+
+Based in the UK, Student Robotics challenges teams of 16 to 19 year-olds to
+design, build and program fully autonomous robots to compete in our annual
+competition. Teams will have just six months to engineer their creations. As
+well as supplying teams with a [kit][kit], which they can use as a framework for
+their robot, we mentor the teams over this period. Thanks to the generosity of
+our sponsors, we provide all of this to our teams at no cost.
+
+The [competition cycle][programme-structure] will start with an in-person
+[Kickstart event][kickstart] hosted at the University of Southampton on October
+12th. During the event the game and the structure of the competition will be
+announced.
+
+The competition year will culminate with an in-person competition over two days
+around Easter 2025. This will see the robots compete through a league stage and
+a seeded knockout. As usual the prizes will recognise not only the teams which
+come top in the knockouts, but also those who excel in other ways.
+
+Details of the game and prizes will be revealed at [Kickstart][kickstart].
+Details of the competition events will be published when they are available.
+We expect to confirm places towards the latter half of September.
+
+We have also created some [pre-Kickstart activities][pre-kickstart-activities]
+which enable anyone to start learning about robotics and our simulator.
+
+If you would like a chance to [compete][compete] in Student Robotics 2026,
+please fill in the [entry form][entry-form] with the required information.
+Places are limited, so sign up soon to avoid disappointment.
+
+We look forward to seeing your teams!
+
+<div class="text-center">
+  <a class="button button-primary" href="{{ site.baseurl }}/compete#signup">
+    Register your interest
+  </a>
+</div>
+
+[kit]: https://studentrobotics.org/docs/kit/
+[programme-structure]: https://studentrobotics.org/docs/robots_101/programme_structure
+
+[kickstart]: {{ '/events/sr2026/kickstart' | prepend: site.baseurl }}
+[compete]: {{ '/compete' | prepend: site.baseurl }}
+[entry-form]: {{ '/compete#signup' | prepend: site.baseurl }}
+[pre-kickstart-activities]: https://studentrobotics.org/docs/competitor_resources/pre_kickstart_activities


### PR DESCRIPTION
This adds the SR2026 Kickstart event and a blog post announcing that registration has opened.